### PR TITLE
[mixin]屠宰工艺dirtyHands取消事件之前检查事件是否可取消

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -251,6 +251,8 @@ dependencies {
     implementation fg.deobf("curse.maven:casualness_delight-909519:5181805")
     //createbicbit
     implementation fg.deobf("curse.maven:createbicbit-918751:6286509")
+    //butchercraft
+    implementation fg.deobf("curse.maven:butchercraft-265715:6058842")
     //sol
     implementation fg.deobf("curse.maven:solapplepie-704584:4596285")
     implementation fg.deobf("curse.maven:solcarrot-277616:4650707")

--- a/gradle.properties
+++ b/gradle.properties
@@ -50,7 +50,7 @@ mod_name=Create Delight Core
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=MIT License
 # The mod version. See https://semver.org/
-mod_version=2.0.1
+mod_version=2.0.2
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/butchercraft/ButchercraftModEventsMixin.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/butchercraft/ButchercraftModEventsMixin.java
@@ -1,0 +1,19 @@
+package io.github.jasonsimpart.createdelightcore.mixin.butchercraft;
+
+import org.spongepowered.asm.mixin.Mixin;
+import com.lance5057.butchercraft.ButchercraftModEvents;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.At;
+import net.minecraftforge.event.entity.living.LivingEntityUseItemEvent;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(value = ButchercraftModEvents.class, remap = false)
+abstract class ButchercraftModEventsMixin {
+    // 在dirtyHands cancel事件之前检查事件是否是可cancel的，避免cancel一个无法cancel的event造成的崩溃
+    @Inject(method = "dirtyHands", at = @At(value = "INVOKE", target = "Lnet/minecraftforge/event/entity/living/LivingEntityUseItemEvent$Finish;setCanceled(Z)V"), cancellable = true)
+        private static void earlyReturnIfNotCancelable(LivingEntityUseItemEvent.Finish event, CallbackInfo info) {
+        if (!event.isCancelable()) {
+            info.cancel();
+        }
+    }
+}

--- a/src/main/resources/mixins.createdelightcore.json
+++ b/src/main/resources/mixins.createdelightcore.json
@@ -10,6 +10,7 @@
     "ae2.CraftingTermMenuMixin",
     "ae2.CraftingTermSlotMixin",
     "bakeries.SnifferEventMixin",
+    "butchercraft.ButchercraftModEventsMixin",
     "CA.EnergyNetWorkMixin",
     "casualness_delight.DeepFryingPanEntityMixin",
     "createbicbit.DeepFryingRecipeMixin",


### PR DESCRIPTION
[mixin]在屠宰工艺dirtyHands cancel事件之前检查事件是否是可cancel的，避免cancel一个无法cancel的event造成的崩溃

