### PR TITLE
修复trueuuid切换游戏模式时因为刷新数据导致的客户端状态更新失败的问题，修改为“只给其他在线玩家刷新皮肤信息，不再给登录者本人发 r…

### DIFF
--- a/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/trueuuid/SkinRefreshHandlerMixin.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/trueuuid/SkinRefreshHandlerMixin.java
@@ -1,0 +1,34 @@
+package io.github.jasonsimpart.createdelightcore.mixin.trueuuid;
+
+import net.minecraft.network.protocol.game.ClientboundPlayerInfoRemovePacket;
+import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerPlayer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.List;
+
+@Pseudo
+@Mixin(targets = "cn.alini.trueuuid.server.SkinRefreshHandler")
+public abstract class SkinRefreshHandlerMixin {
+    @Inject(method = "lambda$onLogin$0", at = @At("HEAD"), cancellable = true, require = 0)
+    private static void createdelightcore$refreshOtherPlayersOnly(MinecraftServer server, ServerPlayer joiningPlayer, CallbackInfo ci) {
+        var playerList = server.getPlayerList();
+        var removePacket = new ClientboundPlayerInfoRemovePacket(List.of(joiningPlayer.getUUID()));
+        var addPacket = ClientboundPlayerInfoUpdatePacket.createPlayerInitializing(List.of(joiningPlayer));
+
+        for (var onlinePlayer : playerList.getPlayers()) {
+            if (onlinePlayer == joiningPlayer) {
+                continue;
+            }
+            onlinePlayer.connection.send(removePacket);
+            onlinePlayer.connection.send(addPacket);
+        }
+
+        ci.cancel();
+    }
+}

--- a/src/main/resources/mixins.createdelightcore.json
+++ b/src/main/resources/mixins.createdelightcore.json
@@ -58,6 +58,7 @@
     "solapplepie.FoodListMixin",
     "solapplepie.FoodTrackerMixin",
     "solcarrot.FoodListMixin",
+    "trueuuid.SkinRefreshHandlerMixin",
     "trader_fresh.RestockEventHandlerMixin",
     "waystones.WaystoneButtonMixin"
   ],


### PR DESCRIPTION
…emove/add 包”