### PR TITLE
[fix] 修复服务器环境中液体燃料tooltip无法显示的问题

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -50,7 +50,7 @@ mod_name=Create Delight Core
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=MIT License
 # The mod version. See https://semver.org/
-mod_version=2.2.12
+mod_version=2.2.13
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/io/github/jasonsimpart/createdelightcore/compat/cmr/LiquidCoolerFuelJsonLoader.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/compat/cmr/LiquidCoolerFuelJsonLoader.java
@@ -1,12 +1,15 @@
 package io.github.jasonsimpart.createdelightcore.compat.cmr;
 
+import com.forsteri.createliquidfuel.core.BurnerStomachHandler;
+import com.forsteri.createliquidfuel.util.Triplet;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.mojang.datafixers.util.Pair;
-import io.github.jasonsimpart.createdelightcore.util.Triplet;
+import io.github.jasonsimpart.createdelightcore.CreateDelightCore;
 import net.minecraft.ResourceLocationException;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.Resource;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.server.packs.resources.SimpleJsonResourceReloadListener;
 import net.minecraft.util.profiling.ProfilerFiller;
@@ -14,6 +17,8 @@ import net.minecraft.world.level.material.Fluid;
 import net.minecraftforge.registries.ForgeRegistries;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.IOException;
+import java.io.Reader;
 import java.util.Map;
 import static io.github.jasonsimpart.createdelightcore.CreateDelightCore.MODID;
 
@@ -32,42 +37,108 @@ public class LiquidCoolerFuelJsonLoader extends SimpleJsonResourceReloadListener
     protected void apply(Map<ResourceLocation, JsonElement> p_10793_, @NotNull ResourceManager p_10794_, @NotNull ProfilerFiller p_10795_) {
         CoolerStomachHandler.LIQUID_COOLER_FUEL_MAP.clear();
         for (Map.Entry<ResourceLocation, JsonElement> entry : p_10793_.entrySet()) {
-            JsonElement element = entry.getValue();
-            if (element.isJsonObject()) {
-                ResourceLocation id = entry.getKey();
-                JsonObject object = element.getAsJsonObject();
-                JsonElement fluidElement = object.get("fluid");
-                if (fluidElement != null) {
-                    try {
-                        Fluid value = ForgeRegistries.FLUIDS.getValue(ResourceLocation.parse(fluidElement.getAsString()));
-                        if (value != null) {
-                            CoolerStomachHandler.LIQUID_COOLER_FUEL_MAP.put(value,
-                                    Pair.of(
-                                            IDENTIFIER,
-                                            Triplet.of(
-                                                object.has("burnTime") ?
-                                                        object.get("burnTime").getAsInt() :
-                                                        object.has("freezing") && object.get("freezing").getAsBoolean() ?
-                                                                32 : 20
-                                                    // Lava Burn Time per Mb is 20, create mod codes sets that 32 * 1000 / 10 for any freezing
-                                                    // This is from BlazeBurnerBlockEntity#tryUpdateFuel (Line 193)
-                                                    , object.has("freezing") && object.get("freezing").getAsBoolean() // default not to freezing
-                                                    , object.has("amountConsumedPerTick") ?
-                                                            object.get("amountConsumedPerTick").getAsInt() :
-                                                            object.has("freezing") && object.get("freezing").getAsBoolean() ?
-                                                                    10 : 1 // default not to consume 10 if freezing, 1 if not
-                                            )
-                                    )
-                                    );
-                        }
-                    } catch (ResourceLocationException e) {
-                        throw new RuntimeException("Fluid liquid cooler fuel " + id + " has invalid fluid: " + fluidElement.getAsString());
-                    }
-                } else {
-                    throw new RuntimeException("No fluid specified for liquid cooler fuel: " + id);
-                }
-            }
+            parseAndAddCoolerFuel(entry.getKey(), entry.getValue());
+        }
+    }
+
+    /**
+     * Client-side loading: read snowman cooler fuel data from local ResourceManager.
+     */
+    public static void loadFromResourceManager(ResourceManager rm) {
+        if (!CoolerStomachHandler.LIQUID_COOLER_FUEL_MAP.isEmpty()) {
+            return;
         }
 
+        Map<ResourceLocation, Resource> resources = rm.listResources("snowman_cooler_fuel", 
+                rl -> rl.getPath().endsWith(".json"));
+        
+        for (Map.Entry<ResourceLocation, Resource> entry : resources.entrySet()) {
+            ResourceLocation id = entry.getKey();
+            try (Reader reader = entry.getValue().openAsReader()) {
+                JsonElement element = GSON.fromJson(reader, JsonElement.class);
+                if (element != null && element.isJsonObject()) {
+                    parseAndAddCoolerFuel(id, element);
+                }
+            } catch (IOException e) {
+                CreateDelightCore.LOGGER.warn("Failed to load snowman cooler fuel data from {}: {}", id, e.getMessage());
+            } catch (ResourceLocationException e) {
+                CreateDelightCore.LOGGER.warn("Invalid fluid in snowman cooler fuel {}: {}", id, e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Client-side loading: read blaze burner fuel data from local ResourceManager.
+     * Handles data for create-liquid-fuel mod.
+     */
+    public static void loadBlazeBurnerFuelFromResourceManager(ResourceManager rm) {
+        Map<ResourceLocation, Resource> resources = rm.listResources("blaze_burner_fuel", 
+                rl -> rl.getPath().endsWith(".json"));
+        
+        for (Map.Entry<ResourceLocation, Resource> entry : resources.entrySet()) {
+            ResourceLocation id = entry.getKey();
+            try (Reader reader = entry.getValue().openAsReader()) {
+                JsonElement element = GSON.fromJson(reader, JsonElement.class);
+                if (element != null && element.isJsonObject()) {
+                    parseAndAddBlazeBurnerFuel(id, element.getAsJsonObject());
+                }
+            } catch (IOException e) {
+                CreateDelightCore.LOGGER.warn("Failed to load blaze burner fuel data from {}: {}", id, e.getMessage());
+            } catch (ResourceLocationException e) {
+                CreateDelightCore.LOGGER.warn("Invalid fluid in blaze burner fuel {}: {}", id, e.getMessage());
+            }
+        }
+    }
+
+    private static void parseAndAddCoolerFuel(ResourceLocation id, JsonElement element) {
+        if (!element.isJsonObject()) return;
+        JsonObject object = element.getAsJsonObject();
+        JsonElement fluidElement = object.get("fluid");
+        if (fluidElement == null) {
+            throw new RuntimeException("No fluid specified for liquid cooler fuel: " + id);
+        }
+        
+        try {
+            Fluid value = ForgeRegistries.FLUIDS.getValue(ResourceLocation.parse(fluidElement.getAsString()));
+            if (value != null) {
+                CoolerStomachHandler.LIQUID_COOLER_FUEL_MAP.put(value,
+                        Pair.of(
+                                IDENTIFIER,
+                                io.github.jasonsimpart.createdelightcore.util.Triplet.of(
+                                    object.has("burnTime") ?
+                                            object.get("burnTime").getAsInt() :
+                                            object.has("freezing") && object.get("freezing").getAsBoolean() ?
+                                                    32 : 20,
+                                    object.has("freezing") && object.get("freezing").getAsBoolean(),
+                                    object.has("amountConsumedPerTick") ?
+                                            object.get("amountConsumedPerTick").getAsInt() :
+                                            object.has("freezing") && object.get("freezing").getAsBoolean() ?
+                                                    10 : 1
+                                )
+                        )
+                );
+            }
+        } catch (ResourceLocationException e) {
+            throw new RuntimeException("Fluid liquid cooler fuel " + id + " has invalid fluid: " + fluidElement.getAsString());
+        }
+    }
+
+    private static void parseAndAddBlazeBurnerFuel(ResourceLocation id, JsonObject object) {
+        JsonElement fluidElement = object.get("fluid");
+        if (fluidElement == null) return;
+
+        Fluid value = ForgeRegistries.FLUIDS.getValue(ResourceLocation.parse(fluidElement.getAsString()));
+        if (value == null) return;
+
+        int burnTime = object.has("burnTime") ? object.get("burnTime").getAsInt() : 20;
+        boolean superHeat = object.has("superHeat") && object.get("superHeat").getAsBoolean();
+        int amountConsumed = object.has("amountConsumedPerTick") ? object.get("amountConsumedPerTick").getAsInt() : 1;
+
+        BurnerStomachHandler.LIQUID_BURNER_FUEL_MAP.put(value,
+                Pair.of(
+                        id,
+                        Triplet.of(burnTime, superHeat, amountConsumed)
+                )
+        );
     }
 }

--- a/src/main/java/io/github/jasonsimpart/createdelightcore/eventhandlers/ClientFuelLoader.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/eventhandlers/ClientFuelLoader.java
@@ -1,0 +1,60 @@
+package io.github.jasonsimpart.createdelightcore.eventhandlers;
+
+import com.forsteri.createliquidfuel.core.BurnerStomachHandler;
+import io.github.jasonsimpart.createdelightcore.compat.cmr.CoolerStomachHandler;
+import io.github.jasonsimpart.createdelightcore.compat.cmr.LiquidCoolerFuelJsonLoader;
+import net.minecraft.client.Minecraft;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
+
+import static io.github.jasonsimpart.createdelightcore.CreateDelightCore.MODID;
+
+/**
+ * Client-side fuel data loader.
+ * Loads liquid fuel data from local ResourceManager on client startup,
+ * ensuring tooltip data is available when playing on servers.
+ */
+@Mod.EventBusSubscriber(modid = MODID, bus = Mod.EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
+public class ClientFuelLoader {
+
+    private static boolean loaded = false;
+
+    @SubscribeEvent
+    public static void onClientSetup(FMLClientSetupEvent event) {
+        event.enqueueWork(() -> {
+            if (loaded) return;
+            loadClientFuelData();
+            loaded = true;
+        });
+    }
+
+    /**
+     * Load fuel data from client's local ResourceManager.
+     * This ensures tooltip info is available when connecting to servers.
+     */
+    public static void loadClientFuelData() {
+        ResourceManager rm = Minecraft.getInstance().getResourceManager();
+
+        // Load snowman cooler fuel (CDC mod)
+        LiquidCoolerFuelJsonLoader.loadFromResourceManager(rm);
+
+        // Load blaze burner fuel (create-liquid-fuel mod)
+        loadBlazeBurnerFuel(rm);
+    }
+
+    /**
+     * Load blaze burner fuel data from datapack.
+     * Handles data for create-liquid-fuel mod's BurnerStomachHandler.
+     */
+    private static void loadBlazeBurnerFuel(ResourceManager rm) {
+        // Only load if the map is empty (client-side)
+        if (!BurnerStomachHandler.LIQUID_BURNER_FUEL_MAP.isEmpty()) {
+            return;
+        }
+
+        LiquidCoolerFuelJsonLoader.loadBlazeBurnerFuelFromResourceManager(rm);
+    }
+}


### PR DESCRIPTION
## 问题背景

在服务器环境中游玩时，液体燃料桶的tooltip无法显示燃烧/冷却信息。

**表现**：手持燃料桶时，tooltip不显示 "按住Shift查看燃烧时间" 等提示。

**单player正常**：单人游戏时tooltip正常显示，因为客户端和服务器共享同一个JVM。

## 问题根因

数据加载逻辑只在服务器端执行，客户端没有收到数据：

| 组件 | 触发时机 | 数据填充 |
|------|----------|----------|
| `AddReloadListenerEvent` | **服务器端资源重载** | 服务器填充Map |
| `FMLCommonSetupEvent` | 客户端+服务器 | 但依赖服务器数据 |
| `ItemTooltipEvent` | **客户端渲染** | 客户端读Map → **空** |

**核心问题**：`SimpleJsonResourceReloadListener` 是Forge的资源重载系统，天然只在服务器端运行，没有网络同步机制。

**参考**：create-liquid-fuel mod 存在相同问题 [Issue #33](https://github.com/Forsteri123/CreateLiquidFuel/issues/33)，至今未修复。

## 解决方案

采用**方案A：客户端FMLClientSetupEvent主动加载本地数据**。

**思路**：整合包客户端和服务器文件一致，客户端可以直接读取本地datapack中的燃料数据。

**实现**：
1. 新增 `ClientFuelLoader.java` - 客户端事件处理器
2. 在 `FMLClientSetupEvent` 时从本地 `ResourceManager` 加载燃料数据
3. 同时处理雪傀儡冷却剂和烈焰人燃烧室的燃料数据

## 优点

- 无需网络同步，架构简单
- 客户端独立加载，不依赖服务器
- 与上游create-liquid-fuel的bug无关，自主可控
- 代码量适中（约50行新增代码）

## 注意

客户端数据可能与服务器不一致（如果datapack不同），但对于整合包场景文件一致，这是可接受的。

## 测试建议

在服务器环境测试：
1. 手持岩浆桶，tooltip应显示燃烧时间信息
2. 手持细雪桶，tooltip应显示冷却时间信息