### PR TITLE
[fix] 尝试修复服务器环境中液体燃料tooltip无法显示的问题

### DIFF
--- a/src/main/java/io/github/jasonsimpart/createdelightcore/CreateDelightCore.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/CreateDelightCore.java
@@ -7,6 +7,7 @@ import io.github.jasonsimpart.createdelightcore.content.recipe.CDFanProcessingTy
 import io.github.jasonsimpart.createdelightcore.event.TooltipEvent;
 import io.github.jasonsimpart.createdelightcore.eventhandlers.ForgeEventsHandler;
 import io.github.jasonsimpart.createdelightcore.eventhandlers.ModEventHandler;
+import io.github.jasonsimpart.createdelightcore.network.CDNetwork;
 import io.github.jasonsimpart.createdelightcore.registry.*;
 import io.github.jasonsimpart.createdelightcore.server.ItemEntityEvent;
 import net.minecraft.resources.ResourceLocation;
@@ -27,6 +28,7 @@ public class CreateDelightCore {
 
     public CreateDelightCore() {
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
+        CDNetwork.register();
         MinecraftForge.EVENT_BUS.register(ItemEntityEvent.class);
         MinecraftForge.EVENT_BUS.register(ForgeEventsHandler.class);
         modEventBus.register(ModEventHandler.class);

--- a/src/main/java/io/github/jasonsimpart/createdelightcore/event/TooltipEvent.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/event/TooltipEvent.java
@@ -1,13 +1,14 @@
 package io.github.jasonsimpart.createdelightcore.event;
 
-import com.forsteri.createliquidfuel.core.BurnerStomachHandler;
 import io.github.jasonsimpart.createdelightcore.CreateDelightCore;
-import io.github.jasonsimpart.createdelightcore.compat.cmr.CoolerStomachHandler;
+import io.github.jasonsimpart.createdelightcore.network.ClientFuelCache;
+import io.github.jasonsimpart.createdelightcore.util.Triplet;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.BucketItem;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.material.Fluid;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -25,63 +26,54 @@ public class TooltipEvent {
     public static void addTooltip(ItemTooltipEvent event){
         ItemStack stack = event.getItemStack();
         if(stack.getItem() instanceof BucketItem bucket){
-            var fluid = bucket.getFluid();
+            Fluid fluid = bucket.getFluid();
             // 烈焰人燃料桶提示
-            if(BurnerStomachHandler.LIQUID_BURNER_FUEL_MAP.containsKey(fluid)){
-                var infoPair = BurnerStomachHandler.LIQUID_BURNER_FUEL_MAP.get(fluid);
-                if(infoPair != null){
-                    var info = infoPair.getSecond();
-                    if(info != null){
-                        Integer burnTime = info.getFirst();
-                        Boolean isSuperHeat = info.getSecond();
-                        Integer amountConsume = info.getThird();
-                        if(burnTime != null && isSuperHeat != null && amountConsume != null){
-                            if( Screen.hasShiftDown()) {
-                                var heatType = isSuperHeat
-                                        ? Component.translatable("tooltip." + CreateDelightCore.MODID + ".superHeat").withStyle(ChatFormatting.BLUE)
-                                        : Component.translatable("tooltip." + CreateDelightCore.MODID + ".Heat").withStyle(ChatFormatting.GOLD);
-                                var burnTimeComponent = Component.literal(formatTime(burnTime)).withStyle(ChatFormatting.GOLD);
-                                var amountConsumeComponent = Component.literal(amountConsume.toString() + " mB").withStyle(ChatFormatting.GOLD);
-                                event.getToolTip().add(Component.translatable("tooltip." + CreateDelightCore.MODID + ".holdShiftHeat"));
-                                event.getToolTip().add(Component.translatable("tooltip." + CreateDelightCore.MODID + ".burnTime").append(burnTimeComponent));
-                                event.getToolTip().add(Component.translatable("tooltip." + CreateDelightCore.MODID + ".amountConsume").append(amountConsumeComponent));
-                                event.getToolTip().add(Component.translatable("tooltip." + CreateDelightCore.MODID + ".heatType").append(heatType));
-                            }
-                            else{
-                                event.getToolTip().add(Component.translatable("tooltip." + CreateDelightCore.MODID + ".holdShiftToSeeHeat"));
-                            }
-                        }
+            Triplet<Integer, Boolean, Integer> burnerInfo = ClientFuelCache.BURNER_MAP.get(fluid);
+            if(burnerInfo != null){
+                Integer burnTime = burnerInfo.getFirst();
+                Boolean isSuperHeat = burnerInfo.getSecond();
+                Integer amountConsume = burnerInfo.getThird();
+                if(burnTime != null && isSuperHeat != null && amountConsume != null){
+                    if( Screen.hasShiftDown()) {
+                        var heatType = isSuperHeat
+                                ? Component.translatable("tooltip." + CreateDelightCore.MODID + ".superHeat").withStyle(ChatFormatting.BLUE)
+                                : Component.translatable("tooltip." + CreateDelightCore.MODID + ".Heat").withStyle(ChatFormatting.GOLD);
+                        var burnTimeComponent = Component.literal(formatTime(burnTime)).withStyle(ChatFormatting.GOLD);
+                        var amountConsumeComponent = Component.literal(amountConsume.toString() + " mB").withStyle(ChatFormatting.GOLD);
+                        event.getToolTip().add(Component.translatable("tooltip." + CreateDelightCore.MODID + ".holdShiftHeat"));
+                        event.getToolTip().add(Component.translatable("tooltip." + CreateDelightCore.MODID + ".burnTime").append(burnTimeComponent));
+                        event.getToolTip().add(Component.translatable("tooltip." + CreateDelightCore.MODID + ".amountConsume").append(amountConsumeComponent));
+                        event.getToolTip().add(Component.translatable("tooltip." + CreateDelightCore.MODID + ".heatType").append(heatType));
+                    }
+                    else{
+                        event.getToolTip().add(Component.translatable("tooltip." + CreateDelightCore.MODID + ".holdShiftToSeeHeat"));
                     }
                 }
             }
             // 雪傀儡冷却剂桶提示
-            if(CoolerStomachHandler.LIQUID_COOLER_FUEL_MAP.containsKey(fluid)){
-                var infoPair = CoolerStomachHandler.LIQUID_COOLER_FUEL_MAP.get(fluid);
-                if(infoPair != null){
-                    var info = infoPair.getSecond();
-                    if(info != null){
-                        Integer coolTime = info.getFirst();
-                        Boolean isSuperCool = info.getSecond();
-                        Integer amountConsume = info.getThird();
-                        if(coolTime != null && isSuperCool != null && amountConsume != null){
-                            if( Screen.hasControlDown()) {
-                                var coolType = isSuperCool
-                                        ? Component.translatable("tooltip." + CreateDelightCore.MODID + ".Frozen").withStyle(ChatFormatting.BLUE)
-                                        : Component.translatable("tooltip." + CreateDelightCore.MODID + ".Cooled").withStyle(ChatFormatting.AQUA);
-                                event.getToolTip().add(Component.translatable("tooltip." + CreateDelightCore.MODID + ".holdControlCool"));
-                                var coolTimeComponent = Component.literal(formatTime(coolTime)).withStyle(ChatFormatting.GOLD);
-                                var amountConsumeComponent = Component.literal(amountConsume.toString() + " mB").withStyle(ChatFormatting.GOLD);
-                                event.getToolTip().add(Component.translatable("tooltip." + CreateDelightCore.MODID + ".coolTime").append(coolTimeComponent));
-                                event.getToolTip().add(Component.translatable("tooltip." + CreateDelightCore.MODID + ".amountConsume").append(amountConsumeComponent));
-                                event.getToolTip().add(Component.translatable("tooltip." + CreateDelightCore.MODID + ".coolType").append(coolType));
-                            }
-                            else{
-                                event.getToolTip().add(Component.translatable("tooltip." + CreateDelightCore.MODID + ".holdControlToSeeCool"));
-                            }
-                        }
+            Triplet<Integer, Boolean, Integer> coolerInfo = ClientFuelCache.COOLER_MAP.get(fluid);
+            if(coolerInfo != null){
+                Integer coolTime = coolerInfo.getFirst();
+                Boolean isSuperCool = coolerInfo.getSecond();
+                Integer amountConsume = coolerInfo.getThird();
+                if(coolTime != null && isSuperCool != null && amountConsume != null){
+                    if( Screen.hasControlDown()) {
+                        var coolType = isSuperCool
+                                ? Component.translatable("tooltip." + CreateDelightCore.MODID + ".Frozen").withStyle(ChatFormatting.BLUE)
+                                : Component.translatable("tooltip." + CreateDelightCore.MODID + ".Cooled").withStyle(ChatFormatting.AQUA);
+                        event.getToolTip().add(Component.translatable("tooltip." + CreateDelightCore.MODID + ".holdControlCool"));
+                        var coolTimeComponent = Component.literal(formatTime(coolTime)).withStyle(ChatFormatting.GOLD);
+                        var amountConsumeComponent = Component.literal(amountConsume.toString() + " mB").withStyle(ChatFormatting.GOLD);
+                        event.getToolTip().add(Component.translatable("tooltip." + CreateDelightCore.MODID + ".coolTime").append(coolTimeComponent));
+                        event.getToolTip().add(Component.translatable("tooltip." + CreateDelightCore.MODID + ".amountConsume").append(amountConsumeComponent));
+                        event.getToolTip().add(Component.translatable("tooltip." + CreateDelightCore.MODID + ".coolType").append(coolType));
+                    }
+                    else{
+                        event.getToolTip().add(Component.translatable("tooltip." + CreateDelightCore.MODID + ".holdControlToSeeCool"));
                     }
                 }
             }
         }
     }
 }
+

--- a/src/main/java/io/github/jasonsimpart/createdelightcore/eventhandlers/ForgeEventsHandler.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/eventhandlers/ForgeEventsHandler.java
@@ -1,14 +1,28 @@
 package io.github.jasonsimpart.createdelightcore.eventhandlers;
 
 import io.github.jasonsimpart.createdelightcore.compat.cmr.LiquidCoolerFuelJsonLoader;
+import io.github.jasonsimpart.createdelightcore.network.CDNetwork;
+import io.github.jasonsimpart.createdelightcore.network.SyncFuelMapsPacket;
 import net.minecraftforge.event.AddReloadListenerEvent;
+import net.minecraftforge.event.OnDatapackSyncEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.network.PacketDistributor;
 
 @Mod.EventBusSubscriber
 public class ForgeEventsHandler {
     @SubscribeEvent
     public static void addReloadListeners(AddReloadListenerEvent event) {
         event.addListener(LiquidCoolerFuelJsonLoader.INSTANCE);
+    }
+
+    @SubscribeEvent
+    public static void onDatapackSync(OnDatapackSyncEvent event) {
+        SyncFuelMapsPacket packet = new SyncFuelMapsPacket();
+        if (event.getPlayer() != null) {
+            CDNetwork.CHANNEL.send(PacketDistributor.PLAYER.with(event::getPlayer), packet);
+        } else {
+            CDNetwork.CHANNEL.send(PacketDistributor.ALL.noArg(), packet);
+        }
     }
 }

--- a/src/main/java/io/github/jasonsimpart/createdelightcore/network/CDNetwork.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/network/CDNetwork.java
@@ -1,0 +1,28 @@
+package io.github.jasonsimpart.createdelightcore.network;
+
+import io.github.jasonsimpart.createdelightcore.CreateDelightCore;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.network.NetworkRegistry;
+import net.minecraftforge.network.simple.SimpleChannel;
+
+public class CDNetwork {
+    private static final String PROTOCOL_VERSION = "1";
+
+    public static final SimpleChannel CHANNEL = NetworkRegistry.newSimpleChannel(
+            ResourceLocation.fromNamespaceAndPath(CreateDelightCore.MODID, "main"),
+            () -> PROTOCOL_VERSION,
+            PROTOCOL_VERSION::equals,
+            PROTOCOL_VERSION::equals
+    );
+
+    public static void register() {
+        int id = 0;
+        CHANNEL.registerMessage(
+                id++,
+                SyncFuelMapsPacket.class,
+                SyncFuelMapsPacket::encode,
+                SyncFuelMapsPacket::decode,
+                SyncFuelMapsPacket::handle
+        );
+    }
+}

--- a/src/main/java/io/github/jasonsimpart/createdelightcore/network/ClientFuelCache.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/network/ClientFuelCache.java
@@ -1,0 +1,12 @@
+package io.github.jasonsimpart.createdelightcore.network;
+
+import io.github.jasonsimpart.createdelightcore.util.Triplet;
+import net.minecraft.world.level.material.Fluid;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ClientFuelCache {
+    public static Map<Fluid, Triplet<Integer, Boolean, Integer>> BURNER_MAP = new HashMap<>();
+    public static Map<Fluid, Triplet<Integer, Boolean, Integer>> COOLER_MAP = new HashMap<>();
+}

--- a/src/main/java/io/github/jasonsimpart/createdelightcore/network/SyncFuelMapsPacket.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/network/SyncFuelMapsPacket.java
@@ -1,0 +1,93 @@
+package io.github.jasonsimpart.createdelightcore.network;
+
+import com.forsteri.createliquidfuel.core.BurnerStomachHandler;
+import io.github.jasonsimpart.createdelightcore.compat.cmr.CoolerStomachHandler;
+import io.github.jasonsimpart.createdelightcore.util.Triplet;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.material.Fluid;
+import net.minecraftforge.network.NetworkEvent;
+import net.minecraftforge.registries.ForgeRegistries;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class SyncFuelMapsPacket {
+
+    private final Map<ResourceLocation, Triplet<Integer, Boolean, Integer>> burnerData;
+    private final Map<ResourceLocation, Triplet<Integer, Boolean, Integer>> coolerData;
+
+    /** Server-side constructor: snapshot current server maps. */
+    public SyncFuelMapsPacket() {
+        this.burnerData = new HashMap<>();
+        BurnerStomachHandler.LIQUID_BURNER_FUEL_MAP.forEach((fluid, pair) -> {
+            ResourceLocation rl = ForgeRegistries.FLUIDS.getKey(fluid);
+            if (rl != null && pair != null && pair.getSecond() != null) {
+                var t = pair.getSecond();
+                burnerData.put(rl, Triplet.of(t.getFirst(), t.getSecond(), t.getThird()));
+            }
+        });
+
+        this.coolerData = new HashMap<>();
+        CoolerStomachHandler.LIQUID_COOLER_FUEL_MAP.forEach((fluid, pair) -> {
+            ResourceLocation rl = ForgeRegistries.FLUIDS.getKey(fluid);
+            if (rl != null && pair != null && pair.getSecond() != null) {
+                var t = pair.getSecond();
+                coolerData.put(rl, Triplet.of(t.getFirst(), t.getSecond(), t.getThird()));
+            }
+        });
+    }
+
+    private SyncFuelMapsPacket(Map<ResourceLocation, Triplet<Integer, Boolean, Integer>> burnerData,
+                                Map<ResourceLocation, Triplet<Integer, Boolean, Integer>> coolerData) {
+        this.burnerData = burnerData;
+        this.coolerData = coolerData;
+    }
+
+    public void encode(FriendlyByteBuf buf) {
+        buf.writeMap(burnerData, FriendlyByteBuf::writeResourceLocation, (b, t) -> {
+            b.writeInt(t.getFirst());
+            b.writeBoolean(t.getSecond());
+            b.writeInt(t.getThird());
+        });
+        buf.writeMap(coolerData, FriendlyByteBuf::writeResourceLocation, (b, t) -> {
+            b.writeInt(t.getFirst());
+            b.writeBoolean(t.getSecond());
+            b.writeInt(t.getThird());
+        });
+    }
+
+    public static SyncFuelMapsPacket decode(FriendlyByteBuf buf) {
+        Map<ResourceLocation, Triplet<Integer, Boolean, Integer>> burnerData = buf.readMap(
+                FriendlyByteBuf::readResourceLocation,
+                b -> Triplet.of(b.readInt(), b.readBoolean(), b.readInt())
+        );
+        Map<ResourceLocation, Triplet<Integer, Boolean, Integer>> coolerData = buf.readMap(
+                FriendlyByteBuf::readResourceLocation,
+                b -> Triplet.of(b.readInt(), b.readBoolean(), b.readInt())
+        );
+        return new SyncFuelMapsPacket(burnerData, coolerData);
+    }
+
+    public void handle(Supplier<NetworkEvent.Context> ctx) {
+        ctx.get().enqueueWork(() -> {
+            ClientFuelCache.BURNER_MAP.clear();
+            burnerData.forEach((rl, triplet) -> {
+                Fluid fluid = ForgeRegistries.FLUIDS.getValue(rl);
+                if (fluid != null) {
+                    ClientFuelCache.BURNER_MAP.put(fluid, triplet);
+                }
+            });
+
+            ClientFuelCache.COOLER_MAP.clear();
+            coolerData.forEach((rl, triplet) -> {
+                Fluid fluid = ForgeRegistries.FLUIDS.getValue(rl);
+                if (fluid != null) {
+                    ClientFuelCache.COOLER_MAP.put(fluid, triplet);
+                }
+            });
+        });
+        ctx.get().setPacketHandled(true);
+    }
+}


### PR DESCRIPTION
**根本原因**：`TooltipEvent` 是客户端事件，但 `BurnerStomachHandler.LIQUID_BURNER_FUEL_MAP` 和 `CoolerStomachHandler.LIQUID_COOLER_FUEL_MAP` 只在服务端由 datapack 的 `SimpleJsonResourceReloadListener` 填充。客户端不会执行该加载逻辑，所以 map 为空，tooltip 无法显示。

**解决方案**：引入服务端→客户端的网络同步机制：

| 新增/修改文件 | 作用 |
|---|---|
| network/CDNetwork.java | 注册 `SimpleChannel` |
| network/ClientFuelCache.java | 客户端本地缓存两份 fuel map |
| network/SyncFuelMapsPacket.java | 将服务端的两份 map 序列化发送、客户端反序列化写入 `ClientFuelCache` |
| eventhandlers/ForgeEventsHandler.java | 监听 `OnDatapackSyncEvent`，在 datapack 加载完成后向客户端推送数据包 |
| event/TooltipEvent.java | 改为从 `ClientFuelCache` 读取，不再直接访问服务端 map |
| CreateDelightCore.java | 构造函数中调用 `CDNetwork.register()` |

流程：服务端加载 datapack → `OnDatapackSyncEvent` 触发 → 发包 → 客户端收包写入 `ClientFuelCache` → `TooltipEvent` 读取缓存展示 tooltip。