### PR TITLE
修复末地被世界生成 mixin 污染

### DIFF
--- a/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/Minecraft/CarverMixin.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/Minecraft/CarverMixin.java
@@ -2,6 +2,8 @@ package io.github.jasonsimpart.createdelightcore.mixin.Minecraft;
 
 import io.github.jasonsimpart.createdelightcore.CDConfig;
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.CarvingMask;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.levelgen.Aquifer;
@@ -48,6 +50,13 @@ public abstract class CarverMixin {
 
         // 2. 获取该垂直柱子在世界生成阶段的"真实地表高度"，排除水
         int surfaceY = chunk.getHeight(Heightmap.Types.OCEAN_FLOOR_WG, localX, localZ);
+        int surfaceBlockY = surfaceY - 1;
+        if (surfaceBlockY >= chunk.getMinBuildHeight() && surfaceBlockY < chunk.getMaxBuildHeight()) {
+            BlockState surfaceState = chunk.getBlockState(new BlockPos(pos.getX(), surfaceBlockY, pos.getZ()));
+            if (surfaceState.is(Blocks.END_STONE) || surfaceState.is(Blocks.NETHERRACK)) {
+                return;
+            }
+        }
 
         // 3. 核心拦截逻辑：如果当前正在尝试雕刻的 Y 坐标，距离地表不到配置的深度限制
         if (pos.getY() >= surfaceY - CDConfig.surfaceDepthLimit) {

--- a/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/Minecraft/NoiseChunkMixin.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/Minecraft/NoiseChunkMixin.java
@@ -4,6 +4,7 @@ import io.github.jasonsimpart.createdelightcore.CDConfig;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.WorldGenRegion;
 import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.StructureManager;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
@@ -29,6 +30,9 @@ public abstract class NoiseChunkMixin {
         if (CDConfig.surfaceDepthLimit <= 0) {
             return;
         }
+        if (!region.getLevel().dimension().equals(Level.OVERWORLD)) {
+            return;
+        }
 
         BlockPos.MutableBlockPos mPos = new BlockPos.MutableBlockPos();
         BlockState stone = Blocks.STONE.defaultBlockState();
@@ -47,7 +51,7 @@ public abstract class NoiseChunkMixin {
                 int surfaceY = chunk.getHeight(Heightmap.Types.OCEAN_FLOOR_WG, localX, localZ);
 
                 // 从推算出的地表往下扫配置的深度限制格
-                for (int y = surfaceY - CDConfig.surfaceDepthLimit; y <= surfaceY; y++) {
+                for (int y = surfaceY - CDConfig.surfaceDepthLimit; y < surfaceY; y++) {
                     if (y < chunk.getMinBuildHeight() || y >= chunk.getMaxBuildHeight()) continue;
 
                     mPos.set(worldX, y, worldZ);


### PR DESCRIPTION
## 变更内容
- 限制 `NoiseChunkMixin` 只在主世界执行，避免末地/下界被 `STONE` 回填逻辑污染。
- 修正噪声洞穴回填扫描范围，避免处理到地表上方一格。
- 在 `CarverMixin` 中跳过末地石和下界岩地表，避免非主世界雕刻逻辑被误拦截。

## 验证
- 已运行 `./gradlew.bat compileJava --no-daemon`，编译通过。

## 说明
- 该修复只影响新生成区块；已经生成坏掉的末地区块需要删除对应区域文件后重新生成。