### PR TITLE
[dev] 记录CDC版本号约定

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ Create Delight Core (CDC) is the custom Forge Java mod for Create-Delight Remake
 ## DEVELOPMENT RULES
 
 - Keep `gradle.properties` `mod_version` aligned with the Create-Delight-Core jar used by the parent modpack.
+- `mod_version` must start with a digit because Forge expands it into `META-INF/mods.toml` and rejects non-numeric-leading versions.
 - When updating the parent submodule pointer, verify the CDC source version and packaged CDC mod version are the same.
 - Registrations flow through `CreateDelightCore.REGISTRATE` and the classes in `registry/`.
 - New mixin classes must also be listed in `src/main/resources/mixins.createdelightcore.json`.


### PR DESCRIPTION
## 变更
- 在 CDC 知识库记录 mod_version 必须以数字开头的约定。

## 原因
- mod_version 会展开进 META-INF/mods.toml，非数字开头版本会被 Forge 拒绝。

## 验证
- 仅文档变更，未运行构建。