### PR TITLE
fix/quark-pipe-faucet

### DIFF
--- a/src/main/java/io/github/jasonsimpart/createdelightcore/CDConfig.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/CDConfig.java
@@ -51,6 +51,10 @@ public class CDConfig
             .defineList("beltGrinderBlockedSandpaperRecipes",
                     List.of("createdelight:sandpaper_polishing/rose_quartz"),
                     obj -> obj instanceof String);
+    private static final ForgeConfigSpec.BooleanValue ENABLE_OPEN_ENDED_PIPE_LAVA_DRAIN_FIX = SERVER_BUILDER
+            .comment("Whether Create open-ended pipes should safely drain lavalogged source blocks, such as Quark grates with lava.")
+            .comment("Disable this only if a pack intentionally wants Create's original lava-draining behavior.")
+            .define("enableOpenEndedPipeLavaDrainFix", true);
     static final ForgeConfigSpec SERVER_SPEC = SERVER_BUILDER.build();
 
 
@@ -63,6 +67,7 @@ public class CDConfig
     public static double lunaSoilBoostChance;
     public static int surfaceDepthLimit;
     public static List<String> beltGrinderBlockedSandpaperRecipes = new ArrayList<>();
+    public static boolean enableOpenEndedPipeLavaDrainFix = true;
 
     @SubscribeEvent
     static void onLoad(final ModConfigEvent event)
@@ -79,6 +84,7 @@ public class CDConfig
         if (event.getConfig().getSpec() == SERVER_SPEC) {
             surfaceDepthLimit = SURFACE_DEPTH_LIMIT.get();
             beltGrinderBlockedSandpaperRecipes = new ArrayList<>(BELT_GRINDER_BLOCKED_SANDPAPER_RECIPES.get());
+            enableOpenEndedPipeLavaDrainFix = ENABLE_OPEN_ENDED_PIPE_LAVA_DRAIN_FIX.get();
         }
     }
 }

--- a/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/create/OpenEndedPipeMixin.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/create/OpenEndedPipeMixin.java
@@ -1,0 +1,145 @@
+package io.github.jasonsimpart.createdelightcore.mixin.create;
+
+import com.simibubi.create.AllFluids;
+import com.simibubi.create.content.fluids.FlowSource;
+import com.simibubi.create.content.fluids.OpenEndedPipe;
+import com.simibubi.create.content.fluids.pipes.VanillaFluidTargets;
+import com.simibubi.create.foundation.advancement.AdvancementBehaviour;
+import com.simibubi.create.foundation.advancement.AllAdvancements;
+import com.simibubi.create.foundation.fluid.FluidHelper;
+import com.simibubi.create.foundation.mixin.accessor.FlowingFluidAccessor;
+import net.createmod.catnip.math.BlockFace;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.LiquidBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.block.state.properties.BooleanProperty;
+import net.minecraft.world.level.material.FluidState;
+import net.minecraft.world.level.material.Fluids;
+import net.minecraftforge.fluids.FluidStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import static net.minecraft.world.level.block.state.properties.BlockStateProperties.WATERLOGGED;
+
+@Mixin(value = OpenEndedPipe.class, remap = false)
+public class OpenEndedPipeMixin extends FlowSource {
+
+    @Unique
+    private static final BooleanProperty createdelightcore$LAVALOGGED = BooleanProperty.create("lavalogged");
+
+    @Shadow
+    private Level world;
+
+    @Shadow
+    private BlockPos outputPos;
+
+    @Shadow
+    private BlockPos pos;
+
+    public OpenEndedPipeMixin(BlockFace location) {
+        super(location);
+    }
+
+    @Inject(method = "removeFluidFromSpace", at = @At("HEAD"), cancellable = true, remap = false)
+    private void createdelightcore$removeFluidFromSpace(boolean simulate, CallbackInfoReturnable<FluidStack> cir) {
+        FluidStack empty = FluidStack.EMPTY;
+        if (world == null) {
+            cir.setReturnValue(empty);
+            cir.cancel();
+            return;
+        }
+        if (!world.isLoaded(outputPos)) {
+            cir.setReturnValue(empty);
+            cir.cancel();
+            return;
+        }
+
+        BlockState state = world.getBlockState(outputPos);
+        FluidState fluidState = state.getFluidState();
+        boolean waterlog = state.hasProperty(WATERLOGGED);
+        boolean lavalog = state.hasProperty(createdelightcore$LAVALOGGED);
+
+        FluidStack drainBlock = VanillaFluidTargets.drainBlock(world, outputPos, state, simulate);
+        if (!drainBlock.isEmpty()) {
+            if (!simulate && state.hasProperty(BlockStateProperties.LEVEL_HONEY)
+                    && AllFluids.HONEY.is(drainBlock.getFluid())) {
+                AdvancementBehaviour.tryAward(world, pos, AllAdvancements.HONEY_DRAIN);
+            }
+            cir.setReturnValue(drainBlock);
+            cir.cancel();
+            return;
+        }
+
+        if (!waterlog && !lavalog && !state.canBeReplaced()) {
+            cir.setReturnValue(empty);
+            cir.cancel();
+            return;
+        }
+
+        if (fluidState.isEmpty() || !fluidState.isSource()) {
+            cir.setReturnValue(empty);
+            cir.cancel();
+            return;
+        }
+
+        FluidStack stack = new FluidStack(fluidState.getType(), 1000);
+
+        if (simulate) {
+            cir.setReturnValue(stack);
+            cir.cancel();
+            return;
+        }
+
+        if (FluidHelper.isWater(stack.getFluid())) {
+            AdvancementBehaviour.tryAward(world, pos, AllAdvancements.WATER_SUPPLY);
+        }
+
+        if (waterlog || lavalog) {
+            if (waterlog) {
+                world.setBlock(outputPos, state.setValue(WATERLOGGED, false), 3);
+                world.scheduleTick(outputPos, Fluids.WATER, 1);
+                state = world.getBlockState(outputPos);
+            }
+            if (lavalog) {
+                world.setBlock(outputPos, state.setValue(createdelightcore$LAVALOGGED, false), 3);
+                world.scheduleTick(outputPos, Fluids.LAVA, 1);
+            }
+            cir.setReturnValue(stack);
+            cir.cancel();
+            return;
+        }
+
+        BlockState newState = fluidState.createLegacyBlock()
+                .setValue(LiquidBlock.LEVEL, 14);
+        FluidState newFluidState = newState.getFluidState();
+
+        if (newFluidState.getType() instanceof FlowingFluidAccessor flowing) {
+            FluidState potentiallyFilled = flowing.create$getNewLiquid(world, outputPos, newState);
+            if (potentiallyFilled.equals(fluidState)) {
+                cir.setReturnValue(stack);
+                cir.cancel();
+                return;
+            }
+        }
+
+        world.setBlock(outputPos, newState, 3);
+        cir.setReturnValue(stack);
+        cir.cancel();
+    }
+
+    /**
+     * @author Pink_Cats
+     * @reason Keep open-ended pipes eligible for the guarded drain path.
+     */
+    @Overwrite
+    public boolean isEndpoint() {
+        return true;
+    }
+}

--- a/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/create/OpenEndedPipeMixin.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/create/OpenEndedPipeMixin.java
@@ -8,6 +8,7 @@ import com.simibubi.create.foundation.advancement.AdvancementBehaviour;
 import com.simibubi.create.foundation.advancement.AllAdvancements;
 import com.simibubi.create.foundation.fluid.FluidHelper;
 import com.simibubi.create.foundation.mixin.accessor.FlowingFluidAccessor;
+import io.github.jasonsimpart.createdelightcore.CDConfig;
 import net.createmod.catnip.math.BlockFace;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
@@ -49,6 +50,10 @@ public class OpenEndedPipeMixin extends FlowSource {
 
     @Inject(method = "removeFluidFromSpace", at = @At("HEAD"), cancellable = true, remap = false)
     private void createdelightcore$removeFluidFromSpace(boolean simulate, CallbackInfoReturnable<FluidStack> cir) {
+        if (!CDConfig.enableOpenEndedPipeLavaDrainFix) {
+            return;
+        }
+
         FluidStack empty = FluidStack.EMPTY;
         if (world == null) {
             cir.setReturnValue(empty);

--- a/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/supplementaries/SupplementariesFaucetFluidPrecisionMixin.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/supplementaries/SupplementariesFaucetFluidPrecisionMixin.java
@@ -1,0 +1,93 @@
+package io.github.jasonsimpart.createdelightcore.mixin.supplementaries;
+
+import net.mehvahdjukaar.moonlight.api.fluids.SoftFluidStack;
+import net.mehvahdjukaar.moonlight.api.fluids.forge.SoftFluidStackImpl;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.util.Mth;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.material.Fluids;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.capability.IFluidHandler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(targets = "net.mehvahdjukaar.supplementaries.common.block.faucet.ForgeFluidTankInteraction", remap = false)
+public class SupplementariesFaucetFluidPrecisionMixin {
+
+    @Unique
+    private static final ThreadLocal<Integer> createdelightcore$pendingExactDrainMb = new ThreadLocal<>();
+
+    @Inject(
+            method = "fill(Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/entity/BlockEntity;Lnet/mehvahdjukaar/moonlight/api/fluids/SoftFluidStack;I)Ljava/lang/Integer;",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    private void createdelightcore$fillNonWaterPrecisely(Level level, BlockPos pos, BlockEntity target,
+                                                         SoftFluidStack fluid, int minAmount,
+                                                         CallbackInfoReturnable<Integer> cir) {
+        createdelightcore$pendingExactDrainMb.remove();
+
+        if (!(fluid instanceof SoftFluidStackImpl impl)) return;
+
+        FluidStack stack = impl.toForgeFluid();
+        if (stack.isEmpty() || stack.getFluid().isSame(Fluids.WATER)) return;
+
+        IFluidHandler handler = target.getCapability(ForgeCapabilities.FLUID_HANDLER, Direction.UP).orElse(null);
+        if (handler == null) return;
+
+        FluidStack attempt = stack.copy();
+        attempt.setAmount(250 * minAmount);
+        if (attempt.isEmpty()) {
+            cir.setReturnValue(null);
+            return;
+        }
+
+        int simulated = handler.fill(attempt, IFluidHandler.FluidAction.SIMULATE);
+        if (simulated <= 0) {
+            cir.setReturnValue(0);
+            return;
+        }
+
+        FluidStack exactFill = attempt.copy();
+        exactFill.setAmount(simulated);
+        int filled = handler.fill(exactFill, IFluidHandler.FluidAction.EXECUTE);
+        target.setChanged();
+
+        if (filled > 0) {
+            createdelightcore$pendingExactDrainMb.set(filled);
+        }
+        cir.setReturnValue(Mth.ceil(filled / 250.0f));
+    }
+
+    @Inject(
+            method = "drain(Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/core/Direction;Lnet/minecraft/world/level/block/entity/BlockEntity;I)V",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    private void createdelightcore$drainExactAmount(Level level, BlockPos pos, Direction dir, BlockEntity source,
+                                                    int amount, CallbackInfo ci) {
+        Integer exactDrain = createdelightcore$pendingExactDrainMb.get();
+        if (exactDrain == null) return;
+
+        createdelightcore$pendingExactDrainMb.remove();
+
+        IFluidHandler handler = source.getCapability(ForgeCapabilities.FLUID_HANDLER, dir).orElse(null);
+        if (handler == null) return;
+
+        FluidStack simulated = handler.drain(exactDrain, IFluidHandler.FluidAction.SIMULATE);
+        if (simulated.getAmount() != exactDrain) {
+            return;
+        }
+
+        handler.drain(exactDrain, IFluidHandler.FluidAction.EXECUTE);
+        source.setChanged();
+        ci.cancel();
+    }
+}

--- a/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/supplementaries/SupplementariesFaucetFluidPrecisionMixin.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/supplementaries/SupplementariesFaucetFluidPrecisionMixin.java
@@ -12,12 +12,14 @@ import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+@Pseudo
 @Mixin(targets = "net.mehvahdjukaar.supplementaries.common.block.faucet.ForgeFluidTankInteraction", remap = false)
 public class SupplementariesFaucetFluidPrecisionMixin {
 

--- a/src/main/resources/mixins.createdelightcore.json
+++ b/src/main/resources/mixins.createdelightcore.json
@@ -86,6 +86,7 @@
     "solapplepie.FoodListMixin",
     "solapplepie.FoodTrackerMixin",
     "solcarrot.FoodListMixin",
+    "supplementaries.SupplementariesFaucetFluidPrecisionMixin",
     "trailandtalesdelight.BuddingLanternFruitBlockMixin",
     "trueuuid.SkinRefreshHandlerMixin",
     "trader_fresh.RestockEventHandlerMixin",

--- a/src/main/resources/mixins.createdelightcore.json
+++ b/src/main/resources/mixins.createdelightcore.json
@@ -34,6 +34,7 @@
     "create.CreateRecipeCategoryMixin",
     "create.FluidIngredientMixin",
     "create.GenericItemFillingMixin",
+    "create.OpenEndedPipeMixin",
     "create.FluidTagIngredientMixin",
     "create.ProcessingRecipeSerializerMixin",
     "createbicbit.DeepFryingRecipeMixin",


### PR DESCRIPTION
1. 移植水龙头的丢流体修复，水正常处理（低占用），其他流体校验可流入空间。
2. 争议修复：夸克铁丝网的刷岩浆漏洞。