### PR TITLE
更新 FTB Ultimine 依赖并修复品质联动

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -221,6 +221,8 @@ dependencies {
     implementation fg.deobf("curse.maven:createaddition-439890:6306951")
     // create utilities j
     implementation fg.deobf("curse.maven:create-utilities-j-1437484:7528356")
+    // MMT - More Materials Tetra New
+    compileOnly fg.deobf("curse.maven:mmt-more-materials-tetra-new-1547763:8236384")
     // runServer 提示：该版本 Lightman's Currency 在 userdev 专服中会加载客户端类。
     // 运行 runServer 前请临时改为 compileOnly；客户端或完整整合包测试时保持 implementation。
     implementation fg.deobf("curse.maven:lightmans-currency-472521:7426828")
@@ -246,8 +248,8 @@ dependencies {
     implementation fg.deobf("curse.maven:create-central-kitchen-820977:6987710")
     implementation fg.deobf("curse.maven:my-nethers-delight-1003673:6529919")
     // ftb ultimine
-    implementation fg.deobf("curse.maven:ftb-library-404465:6164053")
-    implementation fg.deobf("curse.maven:ftb-ultimine-386134:5363345")
+    implementation fg.deobf("curse.maven:ftb-library-forge-404465:5925398")
+    implementation fg.deobf("curse.maven:ftb-ultimine-forge-386134:7880472")
     //abnormal
     implementation fg.deobf("curse.maven:abnormal-core-382216:6408581")
     implementation fg.deobf("curse.maven:gallery-1173553:6133771")

--- a/src/main/java/io/github/jasonsimpart/createdelightcore/CDConfig.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/CDConfig.java
@@ -36,6 +36,10 @@ public class CDConfig
     private static final ForgeConfigSpec.DoubleValue LUNA_SOIL_BOOST_CHANCE = BUILDER
             .comment("The chance for luna soil to boost crops grows.")
             .defineInRange("lunaSoilBoostChance", 0.5, 0, 1);
+    private static final ForgeConfigSpec.BooleanValue LOG_MORE_MOD_TETRA_INDEPENDENT_DAMAGE_MULTIPLIERS = BUILDER
+            .comment("Whether to log More Mod Tetra independent damage multipliers.")
+            .comment("Useful for debugging MMT damage stacking; logs only when MMT reports at least one independent multiplier.")
+            .define("logMoreModTetraIndependentDamageMultipliers", false);
     static final ForgeConfigSpec SPEC = BUILDER.build();
 
     private static final ForgeConfigSpec.Builder SERVER_BUILDER = new ForgeConfigSpec.Builder();
@@ -65,6 +69,7 @@ public class CDConfig
     public static int teleportCost;
     public static boolean useMoneyTeleport;
     public static double lunaSoilBoostChance;
+    public static boolean logMoreModTetraIndependentDamageMultipliers;
     public static int surfaceDepthLimit;
     public static List<String> beltGrinderBlockedSandpaperRecipes = new ArrayList<>();
     public static boolean enableOpenEndedPipeLavaDrainFix = true;
@@ -80,6 +85,7 @@ public class CDConfig
             useMoneyTeleport = USE_MONEY_TELEPORT.get();
             teleportCost = TELEPORT_COST.get();
             lunaSoilBoostChance = LUNA_SOIL_BOOST_CHANCE.get();
+            logMoreModTetraIndependentDamageMultipliers = LOG_MORE_MOD_TETRA_INDEPENDENT_DAMAGE_MULTIPLIERS.get();
         }
         if (event.getConfig().getSpec() == SERVER_SPEC) {
             surfaceDepthLimit = SURFACE_DEPTH_LIMIT.get();

--- a/src/main/java/io/github/jasonsimpart/createdelightcore/content/util/QualityFoodHarvestContext.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/content/util/QualityFoodHarvestContext.java
@@ -1,15 +1,25 @@
 package io.github.jasonsimpart.createdelightcore.content.util;
 
+import de.cadentem.quality_food.capability.LevelData;
+import de.cadentem.quality_food.util.QualityUtils;
 import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
 
 public final class QualityFoodHarvestContext {
     private static final ThreadLocal<BlockPos> CURRENT_CROP_POS = new ThreadLocal<>();
+    private static final ThreadLocal<HarvestData> CURRENT_HARVEST = new ThreadLocal<>();
 
     private QualityFoodHarvestContext() {
     }
 
     public static @Nullable BlockPos getCropPos() {
+        HarvestData harvestData = CURRENT_HARVEST.get();
+        if (harvestData != null) {
+            return harvestData.pos();
+        }
         return CURRENT_CROP_POS.get();
     }
 
@@ -25,5 +35,33 @@ public final class QualityFoodHarvestContext {
             return;
         }
         CURRENT_CROP_POS.set(previous);
+    }
+
+    public static @Nullable HarvestData push(ServerPlayer player, BlockPos pos, BlockState state) {
+        HarvestData previous = CURRENT_HARVEST.get();
+        CURRENT_HARVEST.set(new HarvestData(player, pos.immutable(), state));
+        return previous;
+    }
+
+    public static void pop(@Nullable HarvestData previous) {
+        if (previous == null) {
+            CURRENT_HARVEST.remove();
+            return;
+        }
+        CURRENT_HARVEST.set(previous);
+    }
+
+    public static void applyQuality(ItemStack stack) {
+        HarvestData harvestData = CURRENT_HARVEST.get();
+        if (harvestData == null || stack.isEmpty()) {
+            return;
+        }
+
+        ServerPlayer player = harvestData.player();
+        BlockPos pos = harvestData.pos();
+        QualityUtils.applyQuality(stack, harvestData.state(), LevelData.get(player.level(), pos), player, player.level().getBlockState(pos.below()));
+    }
+
+    public record HarvestData(ServerPlayer player, BlockPos pos, BlockState state) {
     }
 }

--- a/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/ftbultimine/ItemCollectionMixin.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/ftbultimine/ItemCollectionMixin.java
@@ -2,6 +2,7 @@ package io.github.jasonsimpart.createdelightcore.mixin.ftbultimine;
 
 import com.llamalad7.mixinextras.sugar.Local;
 import dev.ftb.mods.ftbultimine.ItemCollection;
+import io.github.jasonsimpart.createdelightcore.content.util.QualityFoodHarvestContext;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.EntityType;
@@ -17,6 +18,11 @@ import java.util.List;
 
 @Mixin(ItemCollection.class)
 public class ItemCollectionMixin {
+    @Inject(method = "add", at = @At("HEAD"), remap = false)
+    private void create_Delight_Core$applyQualityBeforeCollect(ItemStack stack, CallbackInfo ci) {
+        QualityFoodHarvestContext.applyQuality(stack);
+    }
+
     @Inject(method = "drop", at = @At(value = "INVOKE", ordinal = 1, target = "Ljava/util/List;iterator()Ljava/util/Iterator;", shift = At.Shift.AFTER), cancellable = true, remap = false)
     public void dropMixin(Level world, BlockPos pos, CallbackInfo ci, @Local List<ItemStack> stacks) {
         //使用直接的产生掉落物来代替使用popResource

--- a/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/ftbultimine/RightClickHandlersMixin.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/ftbultimine/RightClickHandlersMixin.java
@@ -1,33 +1,47 @@
 package io.github.jasonsimpart.createdelightcore.mixin.ftbultimine;
 
-import com.llamalad7.mixinextras.sugar.Local;
-import de.cadentem.quality_food.capability.LevelData;
-import de.cadentem.quality_food.util.QualityUtils;
-import dev.ftb.mods.ftbultimine.FTBUltiminePlayerData;
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
+import dev.ftb.mods.ftbultimine.ItemCollection;
 import dev.ftb.mods.ftbultimine.RightClickHandlers;
+import dev.ftb.mods.ftbultimine.crops.ICropLikeHandler;
 import io.github.jasonsimpart.createdelightcore.content.util.QualityFoodHarvestContext;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.InteractionHand;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.state.BlockState;
+import org.apache.commons.lang3.mutable.MutableInt;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-
-
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(RightClickHandlers.class)
 public class RightClickHandlersMixin {
-    @Inject(method = "cropHarvesting", at = @At(value = "INVOKE", target = "Ldev/ftb/mods/ftbultimine/ItemCollection;add(Lnet/minecraft/world/item/ItemStack;)V"), remap = false)
-    private static void cropHarvestingApplyQuality(ServerPlayer player, InteractionHand hand, BlockPos clickPos, Direction face, FTBUltiminePlayerData data, CallbackInfoReturnable<Integer> cir, @Local(ordinal = 1) BlockPos pos, @Local BlockState state, @Local ItemStack stack) {
-        BlockPos previous = QualityFoodHarvestContext.push(pos);
-        try {
-            QualityUtils.applyQuality(stack, state, LevelData.get(player.level(), pos), player, player.level().getBlockState(pos.below()));
-        } finally {
-            QualityFoodHarvestContext.pop(previous);
-        }
+    @Inject(method = "lambda$cropHarvesting$2", at = @At("HEAD"), remap = false)
+    private static void create_Delight_Core$pushCropHarvestContext(
+            ServerPlayer player,
+            BlockPos pos,
+            BlockState state,
+            ItemCollection itemCollection,
+            MutableInt clicked,
+            ICropLikeHandler handler,
+            CallbackInfo ci,
+            @Share("create_Delight_Core$previousHarvest") LocalRef<QualityFoodHarvestContext.HarvestData> previousHarvest
+    ) {
+        previousHarvest.set(QualityFoodHarvestContext.push(player, pos, state));
+    }
+
+    @Inject(method = "lambda$cropHarvesting$2", at = @At("RETURN"), remap = false)
+    private static void create_Delight_Core$popCropHarvestContext(
+            ServerPlayer player,
+            BlockPos pos,
+            BlockState state,
+            ItemCollection itemCollection,
+            MutableInt clicked,
+            ICropLikeHandler handler,
+            CallbackInfo ci,
+            @Share("create_Delight_Core$previousHarvest") LocalRef<QualityFoodHarvestContext.HarvestData> previousHarvest
+    ) {
+        QualityFoodHarvestContext.pop(previousHarvest.get());
     }
 }

--- a/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/mmt/EffectLevelEventMixin.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/mmt/EffectLevelEventMixin.java
@@ -1,0 +1,85 @@
+package io.github.jasonsimpart.createdelightcore.mixin.mmt;
+
+import io.github.jasonsimpart.createdelightcore.CDConfig;
+import io.github.jasonsimpart.createdelightcore.CreateDelightCore;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraftforge.event.entity.living.LivingHurtEvent;
+import net.minecraftforge.registries.ForgeRegistries;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.List;
+
+@Pseudo
+@Mixin(targets = "com.inolia_zaicek.more_mod_tetra.Event.Post.EffectLevelEvent", remap = false)
+public class EffectLevelEventMixin {
+    @Shadow
+    private float fixedDamage;
+
+    @Shadow
+    private float normalMulti;
+
+    @Shadow
+    private List<Float> independentMulti;
+
+    @Shadow
+    @Final
+    private LivingEntity attacker;
+
+    @Shadow
+    @Final
+    private LivingEntity target;
+
+    @Shadow
+    @Final
+    public LivingHurtEvent hurtEvent;
+
+    @Inject(method = "addIndependentMulti", at = @At("RETURN"), require = 0)
+    private void createdelightcore$logIndependentDamageMultipliers(float multiplier, CallbackInfo ci) {
+        if (!CDConfig.logMoreModTetraIndependentDamageMultipliers) {
+            return;
+        }
+
+        List<Float> independentMultipliers = List.copyOf(independentMulti);
+        if (independentMultipliers.isEmpty()) {
+            return;
+        }
+
+        float originalDamage = hurtEvent.getAmount();
+        float independentProduct = 1.0F;
+
+        for (float value : independentMultipliers) {
+            independentProduct *= value;
+        }
+
+        float beforeIndependent = (originalDamage + fixedDamage) * (1.0F + normalMulti);
+        float projectedDamage = Math.max(beforeIndependent * independentProduct, 0.0F);
+
+        CreateDelightCore.LOGGER.info(
+                "[CDCore][MMT Damage] attacker={} target={} source={} base={} fixed={} normalMulti={} addedIndependentMultiplier={} independentMultipliers={} independentProduct={} projectedDamageSoFar={}",
+                describe(attacker),
+                describe(target),
+                hurtEvent.getSource().getMsgId(),
+                originalDamage,
+                fixedDamage,
+                normalMulti,
+                multiplier,
+                independentMultipliers,
+                independentProduct,
+                projectedDamage
+        );
+    }
+
+    private static String describe(LivingEntity entity) {
+        if (entity == null) {
+            return "<none>";
+        }
+
+        return entity.getScoreboardName() + "[" + ForgeRegistries.ENTITY_TYPES.getKey(entity.getType()) + "]";
+    }
+}

--- a/src/main/resources/mixins.createdelightcore.json
+++ b/src/main/resources/mixins.createdelightcore.json
@@ -66,6 +66,7 @@
     "Minecraft.HoneyBlockMixin",
     "Minecraft.PlayerMixin",
     "Minecraft.NoiseChunkMixin",
+    "mmt.EffectLevelEventMixin",
     "mynethersdelight.PowderyCaneBlockMixin",
     "mynethersdelight.PowderyCannonBlockMixin",
     "moonlight.SoftFluidStackImplMixin",


### PR DESCRIPTION
﻿## 变更内容

- 更新 FTB Library / FTB Ultimine 的 Forge 依赖到 1.20.1 对应新版。
- 适配新版 FTB Ultimine 的作物连锁收获流程，修复连锁收获时 Quality Food 品质不会正确传递的问题。
- 增加 MMT 独立伤害倍率调试日志配置和对应 mixin，便于排查伤害倍率叠加。

## 编码与换行

- PR 中只包含有实际内容差异的文件，未提交纯换行状态变化。
- 中文内容按 UTF-8 提交，`git diff --cached --check` 已通过。

## 验证

- `./gradlew.bat compileJava --no-daemon`
- `./gradlew.bat build --no-daemon`
