### PR TITLE
修复水龙头损失注入在新版api变化下无效的问题

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -232,6 +232,9 @@ dependencies {
 
     // Moonlight soft-fluid bridge used by Supplementaries faucets.
     compileOnly fg.deobf("curse.maven:moonlight-499980:7541536")
+    compileOnly fg.deobf("curse.maven:supplementaries-412082:7431873")
+    runtimeOnly fg.deobf("curse.maven:moonlight-499980:7541536")
+    runtimeOnly fg.deobf("curse.maven:supplementaries-412082:7431873")
 
     // EclipticSeasons
     compileOnly fg.deobf("curse.maven:ecliptic-seasons-1118306:8267149")

--- a/build.gradle
+++ b/build.gradle
@@ -249,7 +249,8 @@ dependencies {
     // 不需要runData时改为implementation
 //    compileOnly(fg.deobf("curse.maven:create-central-kitchen-820977:6522105"))
     implementation fg.deobf("curse.maven:create-central-kitchen-820977:6987710")
-    implementation fg.deobf("curse.maven:my-nethers-delight-1003673:6529919")
+    // Userdev runClient: this version crashes during its own registry setup; compile only for CDR mixins.
+    compileOnly fg.deobf("curse.maven:my-nethers-delight-1003673:6529919")
     // ftb ultimine
     implementation fg.deobf("curse.maven:ftb-library-forge-404465:5925398")
     implementation fg.deobf("curse.maven:ftb-ultimine-forge-386134:7880472")
@@ -280,7 +281,8 @@ dependencies {
     //createbicbit
     implementation fg.deobf("curse.maven:createbicbit-918751:7270573")
     //butchercraft
-    implementation fg.deobf("curse.maven:butchercraft-265715:6058842")
+    // Userdev runClient: this version crashes during its own registry setup; compile only for CDR mixins.
+    compileOnly fg.deobf("curse.maven:butchercraft-265715:6058842")
     //sol
     implementation fg.deobf("curse.maven:solapplepie-704584:4596285")
     implementation fg.deobf("curse.maven:solcarrot-277616:4650707")

--- a/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/quality_food/QualityFoodMixin.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/quality_food/QualityFoodMixin.java
@@ -1,7 +1,5 @@
 package io.github.jasonsimpart.createdelightcore.mixin.quality_food;
 
-import com.soytutta.mynethersdelight.common.block.PowderyCaneBlock;
-import com.soytutta.mynethersdelight.common.block.PowderyCannonBlock;
 import com.teamabnormals.neapolitan.common.block.MintBlock;
 import com.teamabnormals.neapolitan.common.block.StrawberryBushBlock;
 import de.cadentem.quality_food.capability.LevelData;
@@ -28,8 +26,11 @@ import net.minecraft.world.level.block.CropBlock;
 import net.minecraft.world.level.block.SweetBerryBushBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.block.state.properties.BooleanProperty;
+import net.minecraft.world.level.block.state.properties.Property;
 import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.fml.ModList;
+import net.minecraftforge.registries.ForgeRegistries;
 import net.satisfy.vinery.core.block.GrapeBush;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
@@ -50,6 +51,10 @@ import static de.cadentem.quality_food.util.QualityUtils.isValidQuality;
 public abstract class QualityFoodMixin {
     @Unique
     private static final RandomSource create_Delight_Core$RANDOM = RandomSource.create();
+    @Unique
+    private static final ResourceLocation create_Delight_Core$POWDERY_CANE = new ResourceLocation("mynethersdelight", "powdery_cane");
+    @Unique
+    private static final ResourceLocation create_Delight_Core$POWDERY_CANNON = new ResourceLocation("mynethersdelight", "powdery_cannon");
 
     @Inject(method = "applyQuality(Lnet/minecraft/world/item/ItemStack;Ljava/util/Collection;Lnet/minecraft/world/entity/player/Player;)V", at = @At("HEAD"), cancellable = true, remap = false)
     private static void applyQualityFromIngredientsMixin(ItemStack stack, Collection<ItemStack> ingredients, Player player, CallbackInfo ci) {
@@ -193,10 +198,31 @@ public abstract class QualityFoodMixin {
             cir.setReturnValue(state.getValue(BlockStateProperties.AGE_4) == 4);
         } else if (block instanceof GrapeBush || block instanceof SweetBerryBushBlock) {
             cir.setReturnValue(state.getValue(BlockStateProperties.AGE_3) == 3);
-        } else if (block instanceof PowderyCaneBlock) {
-            cir.setReturnValue(state.getValue(PowderyCaneBlock.LIT));
-        } else if (block instanceof PowderyCannonBlock) {
-            cir.setReturnValue(state.getValue(PowderyCannonBlock.LIT));
+        } else {
+            Boolean myNethersDelightCropLit = create_Delight_Core$getMyNethersDelightCropLit(state, block);
+            if (myNethersDelightCropLit != null) {
+                cir.setReturnValue(myNethersDelightCropLit);
+            }
         }
+    }
+
+    @Unique
+    private static Boolean create_Delight_Core$getMyNethersDelightCropLit(BlockState state, Block block) {
+        if (!ModList.get().isLoaded("mynethersdelight")) {
+            return null;
+        }
+
+        ResourceLocation blockId = ForgeRegistries.BLOCKS.getKey(block);
+        if (!create_Delight_Core$POWDERY_CANE.equals(blockId)
+                && !create_Delight_Core$POWDERY_CANNON.equals(blockId)) {
+            return null;
+        }
+
+        for (Property<?> property : state.getProperties()) {
+            if (property instanceof BooleanProperty litProperty && "lit".equals(litProperty.getName())) {
+                return state.getValue(litProperty);
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/supplementaries/SupplementariesFaucetFluidPrecisionMixin.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/supplementaries/SupplementariesFaucetFluidPrecisionMixin.java
@@ -2,6 +2,7 @@ package io.github.jasonsimpart.createdelightcore.mixin.supplementaries;
 
 import net.mehvahdjukaar.moonlight.api.fluids.SoftFluidStack;
 import net.mehvahdjukaar.moonlight.api.fluids.forge.SoftFluidStackImpl;
+import net.mehvahdjukaar.supplementaries.common.block.faucet.FluidOffer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.util.Mth;
@@ -20,22 +21,24 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Pseudo
-@Mixin(targets = "net.mehvahdjukaar.supplementaries.common.block.faucet.ForgeFluidTankInteraction", remap = false)
+@Mixin(targets = "net.mehvahdjukaar.supplementaries.common.block.faucet.APIFluidTankInteraction", remap = false)
 public class SupplementariesFaucetFluidPrecisionMixin {
 
     @Unique
     private static final ThreadLocal<Integer> createdelightcore$pendingExactDrainMb = new ThreadLocal<>();
 
     @Inject(
-            method = "fill(Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/entity/BlockEntity;Lnet/mehvahdjukaar/moonlight/api/fluids/SoftFluidStack;I)Ljava/lang/Integer;",
+            method = "fill(Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/entity/BlockEntity;Lnet/mehvahdjukaar/supplementaries/common/block/faucet/FluidOffer;)Ljava/lang/Integer;",
             at = @At("HEAD"),
             cancellable = true
     )
     private void createdelightcore$fillNonWaterPrecisely(Level level, BlockPos pos, BlockEntity target,
-                                                         SoftFluidStack fluid, int minAmount,
+                                                         FluidOffer offer,
                                                          CallbackInfoReturnable<Integer> cir) {
         createdelightcore$pendingExactDrainMb.remove();
 
+        SoftFluidStack fluid = offer.fluid();
+        int minAmount = offer.minAmount();
         if (!(fluid instanceof SoftFluidStackImpl impl)) return;
 
         FluidStack stack = impl.toForgeFluid();

--- a/src/main/java/io/github/jasonsimpart/createdelightcore/registry/CDBlocks.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/registry/CDBlocks.java
@@ -1,7 +1,6 @@
 package io.github.jasonsimpart.createdelightcore.registry;
 
 import com.github.alexthe666.iceandfire.block.IafBlockRegistry;
-import com.gumillea.cosmopolitan.core.reg.CosmoBlocks;
 import com.renyigesai.bakeries.block.pizza.PizzaBlock;
 import com.renyigesai.bakeries.block.pizza.RawPizzaBlock;
 import com.simibubi.create.content.decoration.encasing.CasingBlock;
@@ -85,7 +84,7 @@ public class CDBlocks {
                     .properties(p -> p.rarity(Rarity.COMMON))
                     .tab(FOOD_TAB)
                     .build()
-                    .initialProperties(CosmoBlocks.ADZUKI_ICE_CREAM_BRICKS::get)
+                    .initialProperties(() -> Blocks.SNOW_BLOCK)
                     .properties(p -> p
                             .mapColor(MapColor.COLOR_ORANGE))
                     .tag(BlockTags.MINEABLE_WITH_SHOVEL)
@@ -96,7 +95,7 @@ public class CDBlocks {
                     .properties(p -> p.rarity(Rarity.COMMON))
                     .tab(FOOD_TAB)
                     .build()
-                    .initialProperties(CosmoBlocks.ADZUKI_ICE_CREAM_BRICKS::get)
+                    .initialProperties(() -> Blocks.SNOW_BLOCK)
                     .properties(p -> p
                             .mapColor(MapColor.COLOR_PINK))
                     .tag(BlockTags.MINEABLE_WITH_SHOVEL)


### PR DESCRIPTION
1. 修正水龙头损失注入在新版api变化下无效的问题。
2. 修复启动崩溃，将mixin改为可选。
3. 修复定义时序异常，可能导致启动崩溃。