### PR TITLE
增强 MMT 伤害日志输出

### DIFF
--- a/src/main/java/io/github/jasonsimpart/createdelightcore/compat/mmt/MmtDamageLogContext.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/compat/mmt/MmtDamageLogContext.java
@@ -1,0 +1,199 @@
+package io.github.jasonsimpart.createdelightcore.compat.mmt;
+
+import io.github.jasonsimpart.createdelightcore.CDConfig;
+import io.github.jasonsimpart.createdelightcore.CreateDelightCore;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraftforge.event.entity.living.LivingHurtEvent;
+import net.minecraftforge.registries.ForgeRegistries;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+public class MmtDamageLogContext {
+    private static final ThreadLocal<MmtDamageLogContext> CURRENT = new ThreadLocal<>();
+    private static int nextId;
+
+    private final int id;
+    private final LivingHurtEvent hurtEvent;
+    private final float baseDamage;
+    private final List<Contribution> fixedDamage = new ArrayList<>();
+    private final List<Contribution> normalMultipliers = new ArrayList<>();
+    private final List<Contribution> independentMultipliers = new ArrayList<>();
+
+    private MmtDamageLogContext(LivingHurtEvent hurtEvent) {
+        this.id = ++nextId;
+        this.hurtEvent = hurtEvent;
+        this.baseDamage = hurtEvent.getAmount();
+    }
+
+    public static void begin(LivingHurtEvent hurtEvent) {
+        if (!CDConfig.logMoreModTetraIndependentDamageMultipliers) {
+            return;
+        }
+
+        CURRENT.set(new MmtDamageLogContext(hurtEvent));
+    }
+
+    public static void recordFixedDamage(float amount, float total, String operation) {
+        record(fixedDamageList(), amount, total, operation);
+    }
+
+    public static void recordNormalMultiplier(float amount, float total, String operation) {
+        record(normalMultiplierList(), amount, total, operation);
+    }
+
+    public static void recordIndependentMultiplier(float amount, float total) {
+        record(independentMultiplierList(), amount, total, "multiply");
+    }
+
+    public static void finish(LivingHurtEvent hurtEvent) {
+        MmtDamageLogContext context = CURRENT.get();
+        CURRENT.remove();
+
+        if (context == null || context.independentMultipliers.isEmpty()) {
+            return;
+        }
+
+        context.log(hurtEvent);
+    }
+
+    public static void clear() {
+        CURRENT.remove();
+    }
+
+    private static List<Contribution> fixedDamageList() {
+        MmtDamageLogContext context = CURRENT.get();
+        return context == null ? null : context.fixedDamage;
+    }
+
+    private static List<Contribution> normalMultiplierList() {
+        MmtDamageLogContext context = CURRENT.get();
+        return context == null ? null : context.normalMultipliers;
+    }
+
+    private static List<Contribution> independentMultiplierList() {
+        MmtDamageLogContext context = CURRENT.get();
+        return context == null ? null : context.independentMultipliers;
+    }
+
+    private static void record(List<Contribution> contributions, float amount, float total, String operation) {
+        if (contributions == null) {
+            return;
+        }
+
+        contributions.add(new Contribution(operation, amount, total, findMmtCaller()));
+    }
+
+    private void log(LivingHurtEvent finalHurtEvent) {
+        float fixedTotal = lastTotal(fixedDamage);
+        float normalTotal = lastTotal(normalMultipliers);
+        float independentProduct = product(independentMultipliers);
+        float beforeIndependent = (baseDamage + fixedTotal) * (1.0F + normalTotal);
+        float projected = Math.max(beforeIndependent * independentProduct, 0.0F);
+
+        StringBuilder builder = new StringBuilder(640);
+        builder.append("[CDCore][MMT Damage #").append(id).append("]\n");
+        builder.append("  attacker: ").append(describe(hurtEvent.getSource().getEntity())).append('\n');
+        builder.append("  direct:   ").append(describe(hurtEvent.getSource().getDirectEntity())).append('\n');
+        builder.append("  target:   ").append(describe(hurtEvent.getEntity())).append('\n');
+        builder.append("  source:   ").append(hurtEvent.getSource().getMsgId()).append('\n');
+        builder.append("  formula:  max(((base + fixed) * (1 + normalMulti)) * independentProduct, 0)\n");
+        builder.append("  totals:   base=").append(format(baseDamage))
+                .append(", fixed=").append(format(fixedTotal))
+                .append(", normalMulti=").append(format(normalTotal))
+                .append(", independentProduct=").append(format(independentProduct))
+                .append(", projectedBeforeMMTExtraCaps=").append(format(projected))
+                .append(", eventAmountAfterMMT=").append(format(finalHurtEvent.getAmount()))
+                .append('\n');
+
+        appendContributions(builder, "fixed damage", fixedDamage);
+        appendContributions(builder, "normal multiplier", normalMultipliers);
+        appendContributions(builder, "independent multiplier", independentMultipliers);
+
+        CreateDelightCore.LOGGER.info(builder.toString());
+    }
+
+    private static void appendContributions(StringBuilder builder, String title, List<Contribution> contributions) {
+        builder.append("  ").append(title).append(":\n");
+        if (contributions.isEmpty()) {
+            builder.append("    none\n");
+            return;
+        }
+
+        for (int i = 0; i < contributions.size(); i++) {
+            Contribution contribution = contributions.get(i);
+            builder.append("    ").append(i + 1).append(". ")
+                    .append(contribution.operation()).append(' ').append(format(contribution.amount()))
+                    .append(" -> total ").append(format(contribution.total()))
+                    .append(" from ").append(contribution.source().displayName())
+                    .append(" (").append(contribution.source().className()).append('#').append(contribution.source().methodName()).append(")\n");
+        }
+    }
+
+    private static float lastTotal(List<Contribution> contributions) {
+        if (contributions.isEmpty()) {
+            return 0.0F;
+        }
+
+        return contributions.get(contributions.size() - 1).total();
+    }
+
+    private static float product(List<Contribution> contributions) {
+        float result = 1.0F;
+        for (Contribution contribution : contributions) {
+            result *= contribution.amount();
+        }
+        return result;
+    }
+
+    private static Source findMmtCaller() {
+        StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+        for (StackTraceElement element : stackTrace) {
+            String className = element.getClassName();
+            if (!className.startsWith("com.inolia_zaicek.more_mod_tetra.")) {
+                continue;
+            }
+            if (className.equals("com.inolia_zaicek.more_mod_tetra.Event.Post.EffectLevelEvent")) {
+                continue;
+            }
+
+            return new Source(shortClassName(className), element.getMethodName(), humanize(simpleName(className)));
+        }
+
+        return new Source("<unknown>", "<unknown>", "<unknown>");
+    }
+
+    private static String describe(Object entity) {
+        if (!(entity instanceof LivingEntity living)) {
+            return entity == null ? "<none>" : entity.toString();
+        }
+
+        return living.getScoreboardName() + "[" + ForgeRegistries.ENTITY_TYPES.getKey(living.getType()) + "]";
+    }
+
+    private static String shortClassName(String className) {
+        return className.substring("com.inolia_zaicek.more_mod_tetra.".length());
+    }
+
+    private static String simpleName(String className) {
+        int index = className.lastIndexOf('.');
+        return index == -1 ? className : className.substring(index + 1);
+    }
+
+    private static String humanize(String className) {
+        return className
+                .replaceAll("([a-z])([A-Z])", "$1 $2")
+                .replaceAll("([A-Z]+)([A-Z][a-z])", "$1 $2");
+    }
+
+    private static String format(float value) {
+        return String.format(Locale.ROOT, "%.4f", value);
+    }
+
+    private record Contribution(String operation, float amount, float total, Source source) {
+    }
+
+    private record Source(String className, String methodName, String displayName) {
+    }
+}

--- a/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/mmt/EffectLevelEventMixin.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/mmt/EffectLevelEventMixin.java
@@ -1,11 +1,6 @@
 package io.github.jasonsimpart.createdelightcore.mixin.mmt;
 
-import io.github.jasonsimpart.createdelightcore.CDConfig;
-import io.github.jasonsimpart.createdelightcore.CreateDelightCore;
-import net.minecraft.world.entity.LivingEntity;
-import net.minecraftforge.event.entity.living.LivingHurtEvent;
-import net.minecraftforge.registries.ForgeRegistries;
-import org.spongepowered.asm.mixin.Final;
+import io.github.jasonsimpart.createdelightcore.compat.mmt.MmtDamageLogContext;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.Shadow;
@@ -27,59 +22,36 @@ public class EffectLevelEventMixin {
     @Shadow
     private List<Float> independentMulti;
 
-    @Shadow
-    @Final
-    private LivingEntity attacker;
-
-    @Shadow
-    @Final
-    private LivingEntity target;
-
-    @Shadow
-    @Final
-    public LivingHurtEvent hurtEvent;
-
-    @Inject(method = "addIndependentMulti", at = @At("RETURN"), require = 0)
-    private void createdelightcore$logIndependentDamageMultipliers(float multiplier, CallbackInfo ci) {
-        if (!CDConfig.logMoreModTetraIndependentDamageMultipliers) {
-            return;
-        }
-
-        List<Float> independentMultipliers = List.copyOf(independentMulti);
-        if (independentMultipliers.isEmpty()) {
-            return;
-        }
-
-        float originalDamage = hurtEvent.getAmount();
-        float independentProduct = 1.0F;
-
-        for (float value : independentMultipliers) {
-            independentProduct *= value;
-        }
-
-        float beforeIndependent = (originalDamage + fixedDamage) * (1.0F + normalMulti);
-        float projectedDamage = Math.max(beforeIndependent * independentProduct, 0.0F);
-
-        CreateDelightCore.LOGGER.info(
-                "[CDCore][MMT Damage] attacker={} target={} source={} base={} fixed={} normalMulti={} addedIndependentMultiplier={} independentMultipliers={} independentProduct={} projectedDamageSoFar={}",
-                describe(attacker),
-                describe(target),
-                hurtEvent.getSource().getMsgId(),
-                originalDamage,
-                fixedDamage,
-                normalMulti,
-                multiplier,
-                independentMultipliers,
-                independentProduct,
-                projectedDamage
-        );
+    @Inject(method = "addFixedDamage", at = @At("RETURN"), require = 0)
+    private void createdelightcore$recordFixedDamage(float amount, CallbackInfo ci) {
+        MmtDamageLogContext.recordFixedDamage(amount, fixedDamage, "add");
     }
 
-    private static String describe(LivingEntity entity) {
-        if (entity == null) {
-            return "<none>";
-        }
+    @Inject(method = "setFixedDamage", at = @At("RETURN"), require = 0)
+    private void createdelightcore$recordSetFixedDamage(float amount, CallbackInfo ci) {
+        MmtDamageLogContext.recordFixedDamage(amount, fixedDamage, "set");
+    }
 
-        return entity.getScoreboardName() + "[" + ForgeRegistries.ENTITY_TYPES.getKey(entity.getType()) + "]";
+    @Inject(method = "addNormalMulti", at = @At("RETURN"), require = 0)
+    private void createdelightcore$recordNormalMultiplier(float amount, CallbackInfo ci) {
+        MmtDamageLogContext.recordNormalMultiplier(amount, normalMulti, "add");
+    }
+
+    @Inject(method = "setNormalMulti", at = @At("RETURN"), require = 0)
+    private void createdelightcore$recordSetNormalMultiplier(float amount, CallbackInfo ci) {
+        MmtDamageLogContext.recordNormalMultiplier(amount, normalMulti, "set");
+    }
+
+    @Inject(method = "addIndependentMulti", at = @At("RETURN"), require = 0)
+    private void createdelightcore$recordIndependentDamageMultiplier(float multiplier, CallbackInfo ci) {
+        MmtDamageLogContext.recordIndependentMultiplier(multiplier, product(independentMulti));
+    }
+
+    private static float product(List<Float> values) {
+        float result = 1.0F;
+        for (float value : values) {
+            result *= value;
+        }
+        return result;
     }
 }

--- a/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/mmt/MMTDamageCalculateMixin.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/mmt/MMTDamageCalculateMixin.java
@@ -1,0 +1,23 @@
+package io.github.jasonsimpart.createdelightcore.mixin.mmt;
+
+import io.github.jasonsimpart.createdelightcore.compat.mmt.MmtDamageLogContext;
+import net.minecraftforge.event.entity.living.LivingHurtEvent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Pseudo
+@Mixin(targets = "com.inolia_zaicek.more_mod_tetra.Event.MMTDamageCalculate", remap = false)
+public class MMTDamageCalculateMixin {
+    @Inject(method = "hurt", at = @At("HEAD"), require = 0)
+    private static void createdelightcore$beginDamageLog(LivingHurtEvent event, CallbackInfo ci) {
+        MmtDamageLogContext.begin(event);
+    }
+
+    @Inject(method = "hurt", at = @At("RETURN"), require = 0)
+    private static void createdelightcore$finishDamageLog(LivingHurtEvent event, CallbackInfo ci) {
+        MmtDamageLogContext.finish(event);
+    }
+}

--- a/src/main/resources/mixins.createdelightcore.json
+++ b/src/main/resources/mixins.createdelightcore.json
@@ -67,6 +67,7 @@
     "Minecraft.PlayerMixin",
     "Minecraft.NoiseChunkMixin",
     "mmt.EffectLevelEventMixin",
+    "mmt.MMTDamageCalculateMixin",
     "mynethersdelight.PowderyCaneBlockMixin",
     "mynethersdelight.PowderyCannonBlockMixin",
     "moonlight.SoftFluidStackImplMixin",


### PR DESCRIPTION
## 变更内容
- 将 MMT 伤害日志从逐次乘区输出改为一次攻击一组汇总报告。
- 记录 fixed damage、normal multiplier、independent multiplier 的每个贡献来源，包括来源类和方法。
- 增加 MMTDamageCalculate 生命周期 mixin，在伤害计算开始记录 base，在结束时统一输出最终公式和合计值。

## 验证
- $env:GRADLE_OPTS='-Xmx2G'; .\gradlew compileJava --no-daemon

## 编码说明
- 代码新增内容保持 ASCII/UTF-8 安全；中文仅用于提交信息和 PR 描述。