### PR TITLE
fix: 关闭动力磨床配方过滤日志避免刷屏

### DIFF
--- a/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/createmetallurgy/BeltGrinderBlockEntityMixin.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/createmetallurgy/BeltGrinderBlockEntityMixin.java
@@ -1,10 +1,8 @@
 package io.github.jasonsimpart.createdelightcore.mixin.createmetallurgy;
 
-import com.mojang.logging.LogUtils;
 import fr.lucreeper74.createmetallurgy.content.blocks.belt_grinder.BeltGrinderBlockEntity;
 import io.github.jasonsimpart.createdelightcore.CDConfig;
 import net.minecraft.world.item.crafting.Recipe;
-import org.slf4j.Logger;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -15,8 +13,6 @@ import java.util.List;
 
 @Mixin(value = BeltGrinderBlockEntity.class, remap = false)
 public class BeltGrinderBlockEntityMixin {
-
-    private static final Logger LOGGER = LogUtils.getLogger();
 
     @Inject(method = "getRecipes", at = @At("RETURN"), cancellable = true)
     private void createdelightcore$filterBlockedSandpaperRecipes(CallbackInfoReturnable<List<? extends Recipe<?>>> cir) {
@@ -34,7 +30,6 @@ public class BeltGrinderBlockEntityMixin {
         for (Recipe<?> recipe : recipes) {
             String recipeId = recipe.getId().toString();
             if (blocked.contains(recipeId)) {
-                LOGGER.info("[CDCore] BeltGrinder: blocking recipe {}", recipeId);
                 changed = true;
                 continue;
             }


### PR DESCRIPTION
## 变更
- 移除 BeltGrinder 配方过滤命中时的 info 日志避免刷屏
- 保留被配置配方的过滤行为不变

## 原因
`BeltGrinderBlockEntity#getRecipes` 会被持续调用，命中屏蔽配方时每次都会输出：

```text
[CDCore] BeltGrinder: blocking recipe createdelight:sandpaper_polishing/rose_quartz
```

该日志位于热路径，运行时会持续刷屏。

## 验证
- `./gradlew.bat build --no-daemon`

## 归属
该日志由 `0fc7c764` 引入，`git blame` 显示作者为 `KazeShukufuku`。
