### PR TITLE
fix: 修复禁用方块世界生成替换

### DIFF
--- a/docs/DISABLED_CONTENT_KUBEJS.md
+++ b/docs/DISABLED_CONTENT_KUBEJS.md
@@ -32,7 +32,7 @@ Default block policy:
 - hide its block item from creative tabs/search
 - block using its block item
 - block player placement
-- replace matching `setBlock` / worldgen placements with air
+- replace matching `setBlock`, chunk writes, and worldgen placements with air
 
 ## Item Rules
 
@@ -114,6 +114,8 @@ Available block policies:
 
 `replaceWith(...)` is an alias for `replaceGeneratedWith(...)`.
 
+`replaceGeneratedWith(...)` only changes the replacement block. By itself it still uses the default block policy set. If you combine it with explicit policies such as `.blockPlace()`, CDC keeps replacement enabled too, regardless of chain order.
+
 如果想把矿石替换成石头，可以写：
 
 ```js
@@ -143,5 +145,6 @@ CDC does not scan player inventories, dropped items, containers, or existing chu
 - 规则存储和匹配：`io.github.jasonsimpart.disabled.DisabledContentManager`
 - NeoForge 事件拦截：`io.github.jasonsimpart.disabled.DisabledContentEvents`
 - 方块替换 mixin：
+  - `io.github.jasonsimpart.mixin.minecraft.ChunkAccessDisabledBlockMixin`
   - `io.github.jasonsimpart.mixin.minecraft.LevelDisabledBlockMixin`
   - `io.github.jasonsimpart.mixin.minecraft.WorldGenRegionDisabledBlockMixin`

--- a/src/main/java/io/github/jasonsimpart/disabled/DisabledRule.java
+++ b/src/main/java/io/github/jasonsimpart/disabled/DisabledRule.java
@@ -84,12 +84,17 @@ public final class DisabledRule {
 
     public DisabledRule policy(DisablePolicy policy) {
         policies.add(policy);
+        if (target == DisabledRuleTarget.BLOCK && replacement != null && policy != DisablePolicy.REPLACE_BLOCK) {
+            policies.add(DisablePolicy.REPLACE_BLOCK);
+        }
         return this;
     }
 
     public DisabledRule replacement(BlockState replacement) {
         this.replacement = replacement;
-        policy(DisablePolicy.REPLACE_BLOCK);
+        if (!policies.isEmpty()) {
+            policies.add(DisablePolicy.REPLACE_BLOCK);
+        }
         return this;
     }
 

--- a/src/main/java/io/github/jasonsimpart/mixin/minecraft/ChunkAccessDisabledBlockMixin.java
+++ b/src/main/java/io/github/jasonsimpart/mixin/minecraft/ChunkAccessDisabledBlockMixin.java
@@ -1,0 +1,25 @@
+package io.github.jasonsimpart.mixin.minecraft;
+
+import io.github.jasonsimpart.disabled.DisabledContentManager;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.level.chunk.ImposterProtoChunk;
+import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraft.world.level.chunk.ProtoChunk;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin({ProtoChunk.class, LevelChunk.class, ImposterProtoChunk.class})
+public abstract class ChunkAccessDisabledBlockMixin {
+    @ModifyVariable(
+            method = "setBlockState(Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;Z)Lnet/minecraft/world/level/block/state/BlockState;",
+            at = @At("HEAD"),
+            argsOnly = true,
+            ordinal = 0
+    )
+    private BlockState createdelightcore$replaceDisabledBlock(BlockState state, BlockPos pos) {
+        return DisabledContentManager.replacementFor(state, (ChunkAccess) (Object) this, pos);
+    }
+}

--- a/src/main/resources/createdelightcore.mixins.json
+++ b/src/main/resources/createdelightcore.mixins.json
@@ -28,6 +28,7 @@
     "cmr.MixinSnowmanCoolerBlock",
     "cmr.MixinSnowmanCoolerBlockEntity",
     "cmr.SnowmanCoolerAccessor",
+    "minecraft.ChunkAccessDisabledBlockMixin",
     "minecraft.LevelDisabledBlockMixin",
     "minecraft.SimpleJsonResourceReloadListenerMixin",
     "minecraft.WorldGenRegionDisabledBlockMixin",


### PR DESCRIPTION
## Summary
- 拦截 ProtoChunk、LevelChunk 和 ImposterProtoChunk 的 setBlockState，覆盖基岩等 chunk 生成写入路径
- 调整 replaceGeneratedWith 语义：单独调用时保留默认禁用策略，和显式策略组合时始终保留替换策略
- 更新 Disabled Content KubeJS API 文档

## Test
- rtk .\\gradlew.bat compileJava --offline --no-daemon --no-configuration-cache --stacktrace