### PR TITLE
fix: 限制CurseMaven依赖仓库解析

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,18 @@ version = mod_version
 group = mod_group_id
 
 repositories {
+    exclusiveContent {
+        forRepository {
+            maven {
+                name = 'CurseMaven'
+                url = 'https://cursemaven.com'
+            }
+        }
+        filter {
+            includeGroup 'curse.maven'
+        }
+    }
+
     mavenLocal()
     maven {
         name = 'Aliyun Public'
@@ -30,10 +42,6 @@ repositories {
     maven {
         name = 'Registrate'
         url = 'https://maven.ithundxr.dev/snapshots'
-    }
-    maven {
-        name = 'CurseMaven'
-        url = 'https://cursemaven.com'
     }
     maven {
         name = 'Jared Maven'


### PR DESCRIPTION
## Summary
- 使用 Gradle exclusiveContent 将 curse.maven 依赖限定到 Cursemaven 仓库
- 避免阿里云 Maven 镜像解析 curse.maven 坐标并因 502 导致 CI 失败

## Test
- .\\gradlew.bat compileJava --no-daemon --no-configuration-cache --stacktrace