### PR TITLE
fix: 使用官方Gradle仓库并限制发布标签

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Validate tag release branch
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        shell: bash
+        run: |
+          git fetch --no-tags origin '+refs/heads/1.21.1:refs/remotes/origin/1.21.1'
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/1.21.1; then
+            echo "::error::Tag $GITHUB_REF_NAME points to $GITHUB_SHA, which is not contained in origin/1.21.1."
+            exit 1
+          fi
+
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -22,14 +22,6 @@ repositories {
     }
 
     mavenLocal()
-    maven {
-        name = 'Aliyun Public'
-        url = 'https://maven.aliyun.com/repository/public'
-    }
-    maven {
-        name = 'Aliyun Central'
-        url = 'https://maven.aliyun.com/repository/central'
-    }
     mavenCentral()
     maven {
         name = 'NeoForge'

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,18 @@ version = mod_version
 group = mod_group_id
 
 repositories {
+    exclusiveContent {
+        forRepository {
+            maven {
+                name = 'CurseMaven'
+                url = 'https://cursemaven.com'
+            }
+        }
+        filter {
+            includeGroup 'curse.maven'
+        }
+    }
+
     mavenLocal()
     maven {
         name = 'Aliyun Public'
@@ -30,10 +42,6 @@ repositories {
     maven {
         name = 'Registrate'
         url = 'https://maven.ithundxr.dev/snapshots'
-    }
-    maven {
-        name = 'CurseMaven'
-        url = 'https://cursemaven.com'
     }
     maven {
         name = 'Jared Maven'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,18 @@
 pluginManagement {
     repositories {
+        exclusiveContent {
+            forRepository {
+                maven {
+                    name = 'NeoForge'
+                    url = 'https://maven.neoforged.net/releases'
+                }
+            }
+            filter {
+                includeGroup 'net.neoforged'
+                includeGroup 'net.neoforged.moddev'
+            }
+        }
+
         mavenLocal()
         maven {
             name = 'Aliyun Gradle Plugin'
@@ -10,7 +23,6 @@ pluginManagement {
             url = 'https://maven.aliyun.com/repository/public'
         }
         gradlePluginPortal()
-        maven { url = 'https://maven.neoforged.net/releases' }
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,14 +14,6 @@ pluginManagement {
         }
 
         mavenLocal()
-        maven {
-            name = 'Aliyun Gradle Plugin'
-            url = 'https://maven.aliyun.com/repository/gradle-plugin'
-        }
-        maven {
-            name = 'Aliyun Public'
-            url = 'https://maven.aliyun.com/repository/public'
-        }
         gradlePluginPortal()
     }
 }


### PR DESCRIPTION
## Summary
- 将 curse.maven 依赖限定到 CurseMaven 官方仓库
- 将 NeoForge Gradle 插件限定到 NeoForge 官方仓库
- 移除 Aliyun Gradle/Maven 镜像仓库，避免镜像 502 影响 CI
- tag 发布时校验 tag commit 必须包含在 origin/1.21.1 历史中，否则在 build/publish 前失败退出

## Test
- .\\gradlew.bat clean build --no-daemon --no-configuration-cache --stacktrace