### PR TITLE
fix: 修复禁用方块客户端区块同步

### DIFF
--- a/src/main/java/io/github/jasonsimpart/mixin/minecraft/LevelChunkDisabledBlockMixin.java
+++ b/src/main/java/io/github/jasonsimpart/mixin/minecraft/LevelChunkDisabledBlockMixin.java
@@ -2,16 +2,21 @@ package io.github.jasonsimpart.mixin.minecraft;
 
 import io.github.jasonsimpart.disabled.DisabledContentManager;
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.chunk.ChunkAccess;
-import net.minecraft.world.level.chunk.ImposterProtoChunk;
-import net.minecraft.world.level.chunk.ProtoChunk;
+import net.minecraft.world.level.chunk.LevelChunk;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
-@Mixin({ProtoChunk.class, ImposterProtoChunk.class})
-public abstract class ChunkAccessDisabledBlockMixin {
+@Mixin(LevelChunk.class)
+public abstract class LevelChunkDisabledBlockMixin {
+    @Shadow
+    @Final
+    Level level;
+
     @ModifyVariable(
             method = "setBlockState(Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;Z)Lnet/minecraft/world/level/block/state/BlockState;",
             at = @At("HEAD"),
@@ -19,6 +24,10 @@ public abstract class ChunkAccessDisabledBlockMixin {
             ordinal = 0
     )
     private BlockState createdelightcore$replaceDisabledBlock(BlockState state, BlockPos pos) {
-        return DisabledContentManager.replacementFor(state, (ChunkAccess) (Object) this, pos);
+        if (this.level.isClientSide) {
+            return state;
+        }
+
+        return DisabledContentManager.replacementFor(state, (LevelChunk) (Object) this, pos);
     }
 }

--- a/src/main/java/io/github/jasonsimpart/mixin/minecraft/LevelDisabledBlockMixin.java
+++ b/src/main/java/io/github/jasonsimpart/mixin/minecraft/LevelDisabledBlockMixin.java
@@ -17,6 +17,10 @@ public abstract class LevelDisabledBlockMixin {
     @ModifyVariable(method = "setBlock", at = @At("HEAD"), argsOnly = true, ordinal = 0)
     private BlockState createdelightcore$replaceDisabledBlock(BlockState state, BlockPos pos) {
         Level level = (Level) (Object) this;
+        if (level.isClientSide) {
+            return state;
+        }
+
         return DisabledContentManager.replacementFor(keepEnceladusDeepWaterLiquid(state, level, pos), level, pos);
     }
 

--- a/src/main/resources/createdelightcore.mixins.json
+++ b/src/main/resources/createdelightcore.mixins.json
@@ -29,6 +29,7 @@
     "cmr.MixinSnowmanCoolerBlockEntity",
     "cmr.SnowmanCoolerAccessor",
     "minecraft.ChunkAccessDisabledBlockMixin",
+    "minecraft.LevelChunkDisabledBlockMixin",
     "minecraft.LevelDisabledBlockMixin",
     "minecraft.SimpleJsonResourceReloadListenerMixin",
     "minecraft.WorldGenRegionDisabledBlockMixin",


### PR DESCRIPTION
## Summary
- skip disabled block replacement on client Level#setBlock
- split LevelChunk replacement so client chunk sync is preserved while server writes remain guarded
- keep ProtoChunk/ImposterProtoChunk worldgen replacement coverage

## Validation
- ./gradlew.bat build