### PR TITLE
修复 Ponder 中 AE2 线缆不连接

### DIFF
--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -1,5 +1,19 @@
 # Lessons Learned
 
+## Ponder 中 AE2 cable bus 连接需要补渲染状态
+
+**日期**: 2026-07-05
+
+**场景**: CDC 给 Ponder 场景展示 AE2 `ae2:cable_bus`。
+
+### 问题
+
+Ponder 使用自己的 `PonderLevel`/schematic world，AE2 cable bus 的 grid 生命周期可能没有正常建立连接，导致 `CableBusContainer#getRenderState()` 里没有邻接连接，视觉上 cable and bus 不会相连。
+
+### 正确做法
+
+在 client mixin 中只针对 `PonderLevel` 修正 `CableBusRenderState`：根据可见邻居补 `connectionTypes`/`cableBusAdjacent`，邻居是 `CableBusBlockEntity` 时直接取 `getCableBus()`，并清掉被 Ponder mask 成空气的方向。
+
 ## Fruit Delight 自定义 fruit 必须走 synthetic lookup 层
 
 **日期**: 2026-07-05

--- a/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/ae2/CableBusContainerPonderMixin.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/ae2/CableBusContainerPonderMixin.java
@@ -1,0 +1,100 @@
+package io.github.jasonsimpart.createdelightcore.mixin.ae2;
+
+import appeng.api.networking.GridHelper;
+import appeng.api.networking.IInWorldGridNodeHost;
+import appeng.api.util.AEColor;
+import appeng.api.util.AECableType;
+import appeng.blockentity.networking.CableBusBlockEntity;
+import appeng.client.render.cablebus.CableBusRenderState;
+import appeng.parts.CableBusContainer;
+import net.createmod.ponder.api.level.PonderLevel;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(CableBusContainer.class)
+public abstract class CableBusContainerPonderMixin {
+    @Shadow(remap = false)
+    public abstract BlockEntity getBlockEntity();
+
+    @Shadow(remap = false)
+    public abstract AECableType getCableConnectionType(Direction side);
+
+    @Shadow(remap = false)
+    public abstract AEColor getColor();
+
+    @Inject(method = "getRenderState", at = @At("RETURN"), remap = false)
+    private void create_Delight_Core$fixPonderConnections(CallbackInfoReturnable<CableBusRenderState> cir) {
+        BlockEntity blockEntity = getBlockEntity();
+        if (blockEntity == null) {
+            return;
+        }
+
+        Level level = blockEntity.getLevel();
+        if (!(level instanceof PonderLevel)) {
+            return;
+        }
+
+        CableBusRenderState renderState = cir.getReturnValue();
+        BlockPos pos = blockEntity.getBlockPos();
+
+        for (Direction direction : Direction.values()) {
+            BlockPos neighborPos = pos.relative(direction);
+            if (!level.getBlockState(neighborPos).isAir()) {
+                create_Delight_Core$addPonderConnection(level, renderState, direction, neighborPos);
+                continue;
+            }
+
+            renderState.getConnectionTypes().remove(direction);
+            renderState.getCableBusAdjacent().remove(direction);
+            renderState.getChannelsOnSide().put(direction, 0);
+        }
+    }
+
+    @Unique
+    private void create_Delight_Core$addPonderConnection(Level level, CableBusRenderState renderState, Direction direction, BlockPos neighborPos) {
+        IInWorldGridNodeHost neighborHost = create_Delight_Core$getNeighborHost(level, neighborPos);
+        if (neighborHost == null) {
+            return;
+        }
+
+        AECableType localType = getCableConnectionType(direction);
+        AECableType neighborType = neighborHost.getCableConnectionType(direction.getOpposite());
+        if (!localType.isValid() || !neighborType.isValid()) {
+            return;
+        }
+
+        if (neighborHost instanceof CableBusContainer neighborCableBus && !create_Delight_Core$canConnectToCableBus(neighborCableBus)) {
+            return;
+        }
+
+        renderState.getConnectionTypes().put(direction, AECableType.min(localType, neighborType));
+        if (neighborHost instanceof CableBusContainer) {
+            renderState.getCableBusAdjacent().add(direction);
+        }
+    }
+
+    @Unique
+    private IInWorldGridNodeHost create_Delight_Core$getNeighborHost(Level level, BlockPos neighborPos) {
+        BlockEntity neighborBlockEntity = level.getBlockEntity(neighborPos);
+        if (neighborBlockEntity instanceof CableBusBlockEntity cableBusBlockEntity) {
+            return cableBusBlockEntity.getCableBus();
+        }
+
+        return GridHelper.getNodeHost(level, neighborPos);
+    }
+
+    @Unique
+    private boolean create_Delight_Core$canConnectToCableBus(CableBusContainer neighborCableBus) {
+        AEColor color = getColor();
+        AEColor neighborColor = neighborCableBus.getColor();
+        return color == AEColor.TRANSPARENT || neighborColor == AEColor.TRANSPARENT || color == neighborColor;
+    }
+}

--- a/src/main/resources/mixins.createdelightcore.json
+++ b/src/main/resources/mixins.createdelightcore.json
@@ -103,6 +103,7 @@
     "waystones.WaystoneButtonMixin"
   ],
   "client": [
+    "ae2.CableBusContainerPonderMixin",
     "cosmopolitan.CosmoJEIPluginMixin",
     "createdieselgenerators.BulkFermenterRendererMixin"
   ],


### PR DESCRIPTION
## 变更内容
- 新增 AE2 `CableBusContainer` 的客户端 mixin，仅在 `PonderLevel` 中补全 cable bus 的渲染连接状态。
- 邻居是 `CableBusBlockEntity` 时直接读取 `getCableBus()`，否则回退到 AE2 `GridHelper.getNodeHost()`。
- 注册 client mixin，并在 lessons 中记录 Ponder 假世界导致 AE2 grid 连接缺失的坑。

## 原因
Ponder 使用示意世界，AE2 的 grid/node 生命周期可能不会完整建立，导致 `ae2:cable_bus` 在 Ponder 场景中没有邻接渲染状态，看起来线缆和 bus 完全不连接。

## 影响范围
- 仅影响 Ponder 客户端渲染状态。
- 普通世界中的 AE2 连接逻辑仍由 AE2 自身处理。

## 验证
- `./gradlew.bat reobfJar --no-daemon`
- 确认输出 jar 包含 `CableBusContainerPonderMixin.class` 和 `mixins.createdelightcore.json`