### PR TITLE
修复花簇被机械手采收时的 Farmer's Delight 版本崩溃

### DIFF
--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -82,3 +82,13 @@ Fruit Delight 内部部分 jelly / jello 逻辑按 `FruitType` enum ordinal 查�
 ### 规则
 
 虚拟流体如果有同名承载方块，`FluidType` 要显式返回 `fluid.<namespace>.<path>` 描述键；否则 `FluidStack#getDisplayName()` 可能落到方块翻译键，显示成块名。
+
+## 不要把 Farmer's Delight 辅助方法当作跨版本 API
+
+**日期**: 2026-07-21
+
+**场景**: `FlowerClusterBlock` 同时需要识别剪刀与刀具。Farmer's Delight 1.3.2 提供了 `ItemUtils.isValidTool` / `isKnife`，但整合包使用的 1.2.11 没有这两个方法，会使 Create Deployer 反复抛出 `NoSuchMethodError`。
+
+### 规则
+
+跨 Farmer's Delight 版本的基础工具判断应只使用 Forge/Minecraft 稳定 API：剪刀使用 `ItemStack.canPerformAction(ToolActions.SHEARS_HARVEST)` 或 `forge:shears` 标签；刀具使用 `knife_harvest` 动作或 `forge:tools/knives` 标签。不要直接链接版本新增的 `ItemUtils` 方法。

--- a/src/main/java/io/github/jasonsimpart/createdelightcore/content/block/FlowerClusterBlock.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/content/block/FlowerClusterBlock.java
@@ -4,9 +4,12 @@ import de.cadentem.quality_food.capability.LevelData;
 import de.cadentem.quality_food.util.DropData;
 import io.github.jasonsimpart.createdelightcore.registry.CDBlocks;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
+import net.minecraft.tags.TagKey;
 import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.InteractionHand;
@@ -28,13 +31,18 @@ import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.Tags;
+import net.minecraftforge.common.ToolAction;
 import net.minecraftforge.common.ToolActions;
-import vectorwing.farmersdelight.common.utility.ItemUtils;
 
 import java.util.function.Supplier;
 
 public class FlowerClusterBlock extends BushBlock implements BonemealableBlock {
     public static final IntegerProperty CLUSTER_AGE = IntegerProperty.create("age", 0, 2);
+    private static final TagKey<Item> KNIVES = TagKey.create(
+            Registries.ITEM,
+            new ResourceLocation("forge", "tools/knives")
+    );
+    private static final ToolAction KNIFE_HARVEST = ToolAction.get("knife_harvest");
 
     protected static final VoxelShape[] SHAPE_BY_AGE = new VoxelShape[]{
             Block.box(4.0D, 0.0D, 4.0D, 12.0D, 8.0D, 12.0D),
@@ -59,7 +67,7 @@ public class FlowerClusterBlock extends BushBlock implements BonemealableBlock {
         }
 
         ItemStack dropStack = this.getCloneItemStack(level, pos, state);
-        if (ItemUtils.isValidTool(heldStack, ToolActions.SHEARS_HARVEST, Tags.Items.SHEARS)) {
+        if (isShears(heldStack)) {
             level.setBlock(pos, state.setValue(CLUSTER_AGE, age - 1), 2);
             level.playSound(null, pos, SoundEvents.SHEEP_SHEAR, SoundSource.BLOCKS, 1.0F, 1.0F);
             popResourceWithQualityData(state, level, pos, player, dropStack);
@@ -72,7 +80,7 @@ public class FlowerClusterBlock extends BushBlock implements BonemealableBlock {
             return InteractionResult.sidedSuccess(level.isClientSide);
         }
 
-        if (ItemUtils.isKnife(heldStack)) {
+        if (isKnife(heldStack)) {
             dropStack.setCount(age);
             level.setBlock(pos, state.setValue(CLUSTER_AGE, 0), 2);
             level.playSound(null, pos, this.soundType.getBreakSound(), SoundSource.BLOCKS, 1.0F, 1.0F);
@@ -147,6 +155,14 @@ public class FlowerClusterBlock extends BushBlock implements BonemealableBlock {
 
     private static boolean isLunaSoil(BlockState state) {
         return state.is(CDBlocks.LUNA_SOIL.get()) || state.is(CDBlocks.LUNA_SOIL_FARMLAND.get());
+    }
+
+    private static boolean isShears(ItemStack stack) {
+        return stack.canPerformAction(ToolActions.SHEARS_HARVEST) || stack.is(Tags.Items.SHEARS);
+    }
+
+    private static boolean isKnife(ItemStack stack) {
+        return stack.canPerformAction(KNIFE_HARVEST) || stack.is(KNIVES);
     }
 
     private static void popResourceWithQualityData(BlockState state, Level level, BlockPos pos, Player player, ItemStack dropStack) {


### PR DESCRIPTION
## 根因

`FlowerClusterBlock` 使用了 Farmer's Delight 1.3.2 新增的 `ItemUtils.isValidTool` 与 `ItemUtils.isKnife`。整合包服务器实际运行 Farmer's Delight 1.2.11，两个方法均不存在；Create Deployer 收获花簇时会连续抛出 `NoSuchMethodError`，随后被 Neruina 以过多 Tick 异常关服。

## 修改

- 剪刀判断改为 Forge 原生 `SHEARS_HARVEST` 动作或 `forge:shears` 标签。
- 刀具判断改为 `knife_harvest` 动作或稳定的 `forge:tools/knives` 标签。
- 移除对版本新增 `ItemUtils` 方法的链接，保留原有掉落数量、品质数据、耐久消耗、音效和粒子行为。
- 补充 Farmer's Delight 跨版本 API 兼容记录。

## 验证

- 检查 Farmer's Delight 1.2.11：`ItemUtils` 不含两个原调用的方法。
- 检查 Farmer's Delight 1.3.2：替换后的剪刀判断与 `isValidTool` 字节码逻辑等价；刀具仍兼容 `knife_harvest` 动作及通用标签。
- Java 17 执行 `gradlew clean build --no-daemon`，构建成功。
- 检查最终 JAR：不再引用 `ItemUtils.isValidTool` 或 `ItemUtils.isKnife`。