### PR TITLE
[fix] 修复战斗前摇与品控设备掉落

### DIFF
--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -123,3 +123,11 @@ Fruit Delight 内部部分 jelly / jello 逻辑按 `FruitType` enum ordinal 查�
 **问题**: `HoloItemGui` 会在构造时把初始坐标固化进取消选中动画；若分页只在构造后调用 `setX/setY`，从改造详情返回时动画会把入口恢复到未分页坐标并打乱布局。
 
 **正确做法**: 在 `HoloItemGui` 构造调用处把坐标改为页内坐标，再控制各页可见性；升级 Tetra 或 ExtraHoloPage 后复核构造器描述符和 `changeItem` 生命周期。
+
+## Better Combat 零前摇配置受 JAR 下限限制
+
+**日期**: 2026-08-03
+
+**问题**: Better Combat `1.9.0+1.20.1` 的 `ServerConfig.getUpswingMultiplier()` 会把 `upswing_multiplier` 强制夹到至少 `0.2F`，因此整合包配置写成 `0.0` 仍保留前摇。
+
+**正确做法**: 用按 `bettercombat` 模组存在性加载的 `@Pseudo` Mixin 将该常量下限改为 `0.0F`，并保留 `require = 1`；升级 Better Combat 后必须复核方法与常量是否仍匹配。

--- a/gradle.properties
+++ b/gradle.properties
@@ -50,7 +50,7 @@ mod_name=Create Delight Core
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=MIT License
 # The mod version. See https://semver.org/
-mod_version=2.2.16e
+mod_version=2.2.16f
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/generated/resources/data/createdelightcore/loot_tables/blocks/life_matter_injector.json
+++ b/src/generated/resources/data/createdelightcore/loot_tables/blocks/life_matter_injector.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "createdelightcore:life_matter_injector"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "createdelightcore:blocks/life_matter_injector"
+}

--- a/src/generated/resources/data/createdelightcore/loot_tables/blocks/quality_harvest_controller.json
+++ b/src/generated/resources/data/createdelightcore/loot_tables/blocks/quality_harvest_controller.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "createdelightcore:quality_harvest_controller"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "createdelightcore:blocks/quality_harvest_controller"
+}

--- a/src/generated/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
+++ b/src/generated/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
@@ -10,6 +10,8 @@
     "createdelightcore:forge_steel_casing",
     "createdelightcore:fragment_of_border",
     "createdelightcore:order_parser",
-    "createdelightcore:order_requester"
+    "createdelightcore:order_requester",
+    "createdelightcore:quality_harvest_controller",
+    "createdelightcore:life_matter_injector"
   ]
 }

--- a/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/CombatMixinPlugin.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/CombatMixinPlugin.java
@@ -14,6 +14,7 @@ import java.util.Set;
 public final class CombatMixinPlugin implements IMixinConfigPlugin {
     private static final Logger LOGGER = LogManager.getLogger("CreateDelightCore/CombatMixinPlugin");
     private static final String APOTHIC_ATTRIBUTES_MIXIN = ".combat.apothicattributes.";
+    private static final String BETTER_COMBAT_MIXIN = ".combat.bettercombat.";
     private static final String IRONS_SPELLBOOKS_MIXIN = ".combat.ironsspellbooks.";
     private static final String TRAVELOPTICS_MIXIN = ".combat.traveloptics.";
     private static final String EXTRA_HOLO_PAGE_MIXIN = ".extraholopage.";
@@ -31,6 +32,9 @@ public final class CombatMixinPlugin implements IMixinConfigPlugin {
     public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
         if (mixinClassName.contains(APOTHIC_ATTRIBUTES_MIXIN)) {
             return decide(mixinClassName, "attributeslib");
+        }
+        if (mixinClassName.contains(BETTER_COMBAT_MIXIN)) {
+            return decide(mixinClassName, "bettercombat");
         }
         if (mixinClassName.contains(IRONS_SPELLBOOKS_MIXIN)) {
             return decide(mixinClassName, "irons_spellbooks");

--- a/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/combat/bettercombat/ServerConfigMixin.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/combat/bettercombat/ServerConfigMixin.java
@@ -1,0 +1,19 @@
+package io.github.jasonsimpart.createdelightcore.mixin.combat.bettercombat;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Pseudo
+@Mixin(targets = "net.bettercombat.config.ServerConfig", remap = false)
+public class ServerConfigMixin {
+    @ModifyConstant(
+            method = "getUpswingMultiplier",
+            constant = @Constant(floatValue = 0.2F),
+            require = 1
+    )
+    private float createdelightcore$allowZeroUpswingMultiplier(float minimum) {
+        return 0.0F;
+    }
+}

--- a/src/main/java/io/github/jasonsimpart/createdelightcore/registry/CDBlocks.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/registry/CDBlocks.java
@@ -187,6 +187,7 @@ public class CDBlocks {
                             .requiresCorrectToolForDrops())
                     .blockstate((ctx, pvd) -> pvd.simpleBlock(ctx.get(),
                             pvd.models().cubeAll(ctx.getName(), pvd.modLoc("block/forge_steel_casing"))))
+                    .loot((lt, block) -> lt.dropSelf(block))
                     .item()
                     .transform(b -> b.model((ctx, pvd) ->
                             pvd.withExistingParent(ctx.getName(), pvd.modLoc("block/" + ctx.getName()))))
@@ -222,6 +223,7 @@ public class CDBlocks {
                                 .rotationY(rotationY)
                                 .build();
                     }))
+                    .loot((lt, block) -> lt.dropSelf(block))
                     .item()
                     .transform(b -> b.model((ctx, pvd) ->
                             pvd.withExistingParent(ctx.getName(), pvd.modLoc("block/" + ctx.getName()))))

--- a/src/main/resources/mixins.createdelightcore.json
+++ b/src/main/resources/mixins.createdelightcore.json
@@ -91,6 +91,7 @@
     "neapolitan.StrawberryBushBlockMixin",
     "combat.LivingHurtEventMixin",
     "combat.apothicattributes.AttributeEventsMixin",
+    "combat.bettercombat.ServerConfigMixin",
     "combat.ironsspellbooks.EchoingStrikesEffectMixin",
     "combat.traveloptics.ShadowedMiasmaSpellMixin",
     "quality_food.BlockDropContextMixin",


### PR DESCRIPTION
## 改动

- 为 Better Combat `1.9.0+1.20.1` 的 `ServerConfig#getUpswingMultiplier` 解除 `0.2F` 下限，使整合包的 `upswing_multiplier = 0.0` 真正生效。
- 通过 `CombatMixinPlugin` 按 `bettercombat` 模组存在性加载兼容 Mixin。
- 为生命质注入器和品控收割控制器补全自掉落战利品表。
- 将两个方块补入镐可挖掘标签，配合 `requiresCorrectToolForDrops` 正常回收。
- CDC 版本更新至 `2.2.16f`，并记录 Better Combat 升级复核条件。

## 验证

- `./gradlew build --no-daemon`：通过。
- 静态检查 Better Combat 当前 JAR：目标方法包含 `0.2F` 常量下限。
- 检查构建 JAR：包含 Better Combat Mixin class、两张方块 loot table，且 `mods.toml` 版本为 `2.2.16f`。

## 后续

- PR 不自动合并；CDR 将先同步到此提交并更新开发版 CDC JAR，供本地与测试环境验证。