### PR TITLE
[fix] 修复 Northstar 陨石坑月尘下落

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -305,7 +305,7 @@ dependencies {
     implementation fg.deobf("curse.maven:festival-delicacies-1461231:7618167")
 
     implementation fg.deobf("curse.maven:display-delight-1144296:8242933")
-    implementation fg.deobf("curse.maven:northstar-redux-1318310:7476515")
+    implementation fg.deobf("curse.maven:northstar-redux-1318310:8486123")
     implementation fg.deobf("software.bernie.geckolib:geckolib-forge-${minecraft_version}:${geckolib_version}")
     implementation ("com.eliotlash.mclib:mclib:20")
 

--- a/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/northstar/CraterFeatureMixin.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/northstar/CraterFeatureMixin.java
@@ -1,0 +1,31 @@
+package io.github.jasonsimpart.createdelightcore.mixin.northstar;
+
+import com.lightning.northstar.world.gen.feature.CraterFeature;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.WorldGenLevel;
+import net.minecraft.world.level.block.FallingBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(value = CraterFeature.class, remap = false)
+public abstract class CraterFeatureMixin {
+    @Redirect(
+            method = "placeColumnBelow",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/level/WorldGenLevel;setBlock(Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;I)Z",
+                    remap = true
+            ),
+            require = 1
+    )
+    private boolean createdelightcore$placeSupportedCraterFloor(WorldGenLevel level, BlockPos pos, BlockState state, int flags) {
+        if (state.getBlock() instanceof FallingBlock
+                && FallingBlock.isFree(level.getBlockState(pos.below()))) {
+            return false;
+        }
+
+        return level.setBlock(pos, state, flags);
+    }
+}

--- a/src/main/resources/mixins.createdelightcore.json
+++ b/src/main/resources/mixins.createdelightcore.json
@@ -89,6 +89,7 @@
     "neapolitan.MintBlockMixin",
     "neapolitan.NeapolitanJEIPluginMixin",
     "neapolitan.StrawberryBushBlockMixin",
+    "northstar.CraterFeatureMixin",
     "combat.LivingHurtEventMixin",
     "combat.apothicattributes.AttributeEventsMixin",
     "combat.bettercombat.ServerConfigMixin",


### PR DESCRIPTION
## 变更

- 将 Northstar 开发依赖同步到整合包当前锁定的 `0.6.4` 文件。
- 陨石坑坑底待写入下落方块且下方为空时，保留稳定月岩，避免进入模拟范围后批量生成低重力下落实体。

## 验证

- `./gradlew.bat build --no-daemon --console=plain`
- 最终 refmap 已确认 `WorldGenLevel.setBlock` 映射为 `m_7731_`。

## 后续

- 合并后由 CDR 分支指向实际合并提交，重建并同步对应 CDC JAR 后再创建 CDR PR。