### PR TITLE
[fix] 镜像 OEI 合并物品标签

### DIFF
--- a/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/Minecraft/OEITagMirrorMixin.java
+++ b/src/main/java/io/github/jasonsimpart/createdelightcore/mixin/Minecraft/OEITagMirrorMixin.java
@@ -1,0 +1,128 @@
+package io.github.jasonsimpart.createdelightcore.mixin.Minecraft;
+
+import io.github.jasonsimpart.createdelightcore.CreateDelightCore;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.tags.TagEntry;
+import net.minecraft.tags.TagLoader;
+import net.minecraftforge.fml.ModList;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@Mixin(TagLoader.class)
+public abstract class OEITagMirrorMixin {
+    private static final String OEI_MOD_ID = "oneenoughitem";
+    private static final String ITEMS_TAG_DIR = "tags/items";
+    private static final String REPLACEMENT_LOADER = "com.mafuyu404.oneenoughitem.util.MixinUtils$ReplacementLoader";
+    private static final String OEI_CONFIG = "com.mafuyu404.oneenoughitem.init.config.OEIConfig";
+
+    @Shadow
+    @Final
+    private String directory;
+
+    @Inject(method = "load(Lnet/minecraft/server/packs/resources/ResourceManager;)Ljava/util/Map;", at = @At("RETURN"))
+    private void createdelightcore$mirrorOeiItemTags(ResourceManager resourceManager,
+                                                      CallbackInfoReturnable<Map<ResourceLocation, List<TagLoader.EntryWithSource>>> cir) {
+        if (!ITEMS_TAG_DIR.equals(this.directory) || !isOeiDeeperReplaceEnabled()) {
+            return;
+        }
+
+        Map<String, String> mappings = loadOeiMappings(resourceManager);
+        Map<ResourceLocation, List<TagLoader.EntryWithSource>> tags = cir.getReturnValue();
+        if (mappings.isEmpty() || tags == null || tags.isEmpty()) {
+            return;
+        }
+
+        int mirrored = 0;
+        for (Map.Entry<ResourceLocation, List<TagLoader.EntryWithSource>> tag : tags.entrySet()) {
+            ResourceLocation tagId = tag.getKey();
+            List<TagLoader.EntryWithSource> entries = tag.getValue();
+            if (entries == null) {
+                continue;
+            }
+
+            List<TagLoader.EntryWithSource> additions = new ArrayList<>();
+            if (tryMirrorItem(mappings.get("#" + tagId), tagId, "#" + tagId, additions)) {
+                mirrored++;
+            }
+
+            for (TagLoader.EntryWithSource entryWithSource : entries) {
+                TagEntry entry = entryWithSource.entry();
+                if (!entryWithSource.remove() && !entry.isTag()
+                        && tryMirrorItem(mappings.get(entry.getId().toString()), tagId, entry.getId().toString(), additions)) {
+                    mirrored++;
+                }
+            }
+
+            entries.addAll(additions);
+        }
+
+        if (mirrored > 0) {
+            CreateDelightCore.LOGGER.info("OEI item tag mirror: added {} item entries", mirrored);
+        }
+    }
+
+    private static boolean isOeiDeeperReplaceEnabled() {
+        if (!ModList.get().isLoaded(OEI_MOD_ID)) {
+            return false;
+        }
+
+        try {
+            Class<?> configClass = Class.forName(OEI_CONFIG);
+            Object config = configClass.getMethod("get").invoke(null);
+            return config != null && (boolean) config.getClass().getMethod("deeperReplace").invoke(config);
+        } catch (ReflectiveOperationException | LinkageError e) {
+            CreateDelightCore.LOGGER.warn("OEI item tag mirror: cannot read Deeper_Replace", e);
+            return false;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, String> loadOeiMappings(ResourceManager resourceManager) {
+        try {
+            Class<?> loaderClass = Class.forName(REPLACEMENT_LOADER);
+            Method loadCurrentSnapshot = loaderClass.getMethod("loadCurrentSnapshot", ResourceManager.class);
+            Object snapshot = loadCurrentSnapshot.invoke(null, resourceManager);
+            Object mappings = snapshot.getClass().getMethod("dataMap").invoke(snapshot);
+            return mappings instanceof Map<?, ?> map ? (Map<String, String>) map : Collections.emptyMap();
+        } catch (ReflectiveOperationException | LinkageError e) {
+            CreateDelightCore.LOGGER.warn("OEI item tag mirror: cannot load replacement mappings", e);
+            return Collections.emptyMap();
+        }
+    }
+
+    private static boolean tryMirrorItem(String targetItemId, ResourceLocation tagId, String source,
+                                         List<TagLoader.EntryWithSource> additions) {
+        if (targetItemId == null || targetItemId.isBlank() || "minecraft:air".equals(targetItemId)) {
+            return false;
+        }
+
+        try {
+            ResourceLocation targetId = new ResourceLocation(targetItemId);
+            if (BuiltInRegistries.ITEM.getOptional(targetId).isEmpty()) {
+                return false;
+            }
+
+            additions.add(new TagLoader.EntryWithSource(
+                    TagEntry.element(targetId),
+                    "createdelightcore:oei_tag_mirror"
+            ));
+            CreateDelightCore.LOGGER.debug("OEI item tag mirror: add '{}' to {} (source='{}')", targetId, tagId, source);
+            return true;
+        } catch (Exception e) {
+            CreateDelightCore.LOGGER.warn("OEI item tag mirror: invalid target item '{}' from {}", targetItemId, source);
+            return false;
+        }
+    }
+}

--- a/src/main/resources/mixins.createdelightcore.json
+++ b/src/main/resources/mixins.createdelightcore.json
@@ -79,6 +79,7 @@
     "IAF.TabulaModelHandlerHelperMixin",
     "Minecraft.CarverMixin",
     "Minecraft.HoneyBlockMixin",
+    "Minecraft.OEITagMirrorMixin",
     "Minecraft.PlayerMixin",
     "Minecraft.NoiseChunkMixin",
     "mmt.EffectLevelEventMixin",


### PR DESCRIPTION
## 背景

OEI 启用 `Deeper_Replace` 后，替换目标仅在运行时被视作来源物品的等价物，并不会加入来源所属的真实物品标签。以 `culturaldelights:squid` 替换鱼类物品时，`farmersdelight:cooking/stuffed_nautilus_shell` 先把 `#minecraft:fishes` 展开为 Ingredient 候选列表，因此无法匹配 squid。

## 改动

- 在 `TagLoader` 读取 `tags/items` 后，读取 OEI 当前重载映射并把有效替换目标追加至来源的物品标签。
- 直接物品映射镜像到包含该来源的标签；`#tag -> target` 映射只镜像到被明确指定的标签，嵌套父标签继续由原版标签解析继承。
- 仅在 OEI 已加载且 `Deeper_Replace=true` 时启用；忽略空气、无效或未注册目标，不改 OEI 配置和映射格式。

## 验证

- `./gradlew.bat build --no-daemon`
- 已在 Minecraft 中确认 mixin 生效，`culturaldelights:squid` 能按镜像标签满足 `farmersdelight:cooking/stuffed_nautilus_shell` 的鱼类 Ingredient 并正常制作。